### PR TITLE
Remove unused code and simplify option parsing

### DIFF
--- a/asciidoc_dita_toolkit/asciidoc_dita/file_utils.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/file_utils.py
@@ -12,6 +12,7 @@ Intended for use by all scripts in this repository to avoid code duplication and
 """
 import os
 import re
+import argparse
 
 # Regex to split lines and preserve their original line endings
 line_splitter = re.compile(rb'(.*?)(\r\n|\r|\n|$)')
@@ -62,19 +63,17 @@ def write_text_preserve_endings(filepath, lines):
         for text, ending in lines:
             f.write(text + ending)
 
-def common_arg_parser(description):
+def common_arg_parser(parser):
     """
-    Returns an argparse.ArgumentParser with standard options for all scripts:
+    Adds starndard options to the supplied parser:
     -d / --directory: Root directory to search (default: current directory)
     -r / --recursive: Search subdirectories recursively
     -f / --file: Scan only the specified .adoc file
     """
-    import argparse
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument('-d', '--directory', type=str, default='.', help='Root directory to search (default: current directory)')
+    sources = parser.add_mutually_exclusive_group()
+    sources.add_argument('-d', '--directory', type=str, default='.', help='Root directory to search (default: current directory)')
+    sources.add_argument('-f', '--file', type=str, help='Scan only the specified .adoc file')
     parser.add_argument('-r', '--recursive', action='store_true', help='Search subdirectories recursively')
-    parser.add_argument('-f', '--file', type=str, help='Scan only the specified .adoc file')
-    return parser
 
 def process_adoc_files(args, process_file_func):
     """
@@ -83,7 +82,6 @@ def process_adoc_files(args, process_file_func):
     - Otherwise, find all .adoc files (recursively if requested) in the specified directory and process each.
     - process_file_func should be a function that takes a file path.
     """
-    from .file_utils import find_adoc_files, is_valid_adoc_file
     if args.file:
         if is_valid_adoc_file(args.file):
             process_file_func(args.file)
@@ -98,5 +96,4 @@ def is_valid_adoc_file(filepath):
     """
     Returns True if the given path is a regular .adoc file (not a symlink), else False.
     """
-    import os
     return os.path.isfile(filepath) and filepath.endswith('.adoc') and not os.path.islink(filepath)

--- a/asciidoc_dita_toolkit/asciidoc_dita/plugins/ContentType.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/plugins/ContentType.py
@@ -8,6 +8,7 @@ __description__ = "Add a :_mod-docs-content-type: label in .adoc files where tho
 
 import os
 import re
+from ..file_utils import process_adoc_files, common_arg_parser
 
 class highlighter(object):
     def __init__(self, text):
@@ -48,56 +49,29 @@ def editor(filepath, label):
     except Exception as e:
         print(highlighter(f"Error: {e}").warn())
 
-def tree_walker(directory):
+def label_file(filepath):
+    file = os.path.basename(filepath)
+    label = None
 
-    for root, dirs, files in os.walk(directory):
-        for file in files:
-            if file.startswith(".") or not file.endswith(".adoc"):
-                continue
-            filepath = os.path.join(root, file)
-            label = None
-
-            if file.startswith("assembly_") or file.startswith("assembly-"):
-                label = "ASSEMBLY"
-
-            elif file.startswith("con_") or file.startswith("con-"):
-                label = "CONCEPT"
-
-            elif file.startswith("proc_") or file.startswith("proc-"):
-                label = "PROCEDURE"
-
-            elif file.startswith("ref_")  or file.startswith("ref-"):
-                label = "REFERENCE"
-
-            if label:
-                editor(filepath, label)
-            else:
-                pass
+    if file.startswith("assembly_") or file.startswith("assembly-"):
+        label = "ASSEMBLY"
+    elif file.startswith("con_") or file.startswith("con-"):
+        label = "CONCEPT"
+    elif file.startswith("proc_") or file.startswith("proc-"):
+        label = "PROCEDURE"
+    elif file.startswith("ref_")  or file.startswith("ref-"):
+        label = "REFERENCE"
+    elif file.startswith("snip_") or file.startswith("snip-"):
+        label = "SNIPPET"
+    if label:
+        editor(filepath, label)
 
 def main(args):
-    from ..file_utils import process_adoc_files
-    def label_file(filepath):
-        file = os.path.basename(filepath)
-        label = None
-        if file.startswith("assembly_") or file.startswith("assembly-"):
-            label = "ASSEMBLY"
-        elif file.startswith("con_") or file.startswith("con-"):
-            label = "CONCEPT"
-        elif file.startswith("proc_") or file.startswith("proc-"):
-            label = "PROCEDURE"
-        elif file.startswith("ref_")  or file.startswith("ref-"):
-            label = "REFERENCE"
-        if label:
-            editor(filepath, label)
     process_adoc_files(args, label_file)
 
 def register_subcommand(subparsers):
-    parser = subparsers.add_parser(
-        "ContentType",
-        help="Add a :_mod-docs-content-type: label in .adoc files where those are missing, based on filename."
-    )
+    parser = subparsers.add_parser("ContentType", help=__description__)
+
     # Use unified argument parser options
-    parser.add_argument('-d', '--directory', type=str, default='.', help='Root directory to search (default: current directory)')
-    parser.add_argument('-r', '--recursive', action='store_true', help='Search subdirectories recursively')
-    parser.add_argument('-f', '--file', type=str, help='Scan only the specified .adoc file')
+    common_arg_parser(parser)
     parser.set_defaults(func=main)

--- a/asciidoc_dita_toolkit/asciidoc_dita/plugins/EntityReference.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/plugins/EntityReference.py
@@ -75,12 +75,8 @@ def main(args):
     process_adoc_files(args, process_file)
 
 def register_subcommand(subparsers):
-    parser = subparsers.add_parser(
-        "EntityReference",
-        help="Replace unsupported HTML character entity references in .adoc files with AsciiDoc attribute references."
-    )
+    parser = subparsers.add_parser("EntityReference", help=__description__)
+
     # Use unified argument parser options
-    parser.add_argument('-d', '--directory', type=str, default='.', help='Root directory to search (default: current directory)')
-    parser.add_argument('-r', '--recursive', action='store_true', help='Search subdirectories recursively')
-    parser.add_argument('-f', '--file', type=str, help='Scan only the specified .adoc file')
+    common_arg_parser(parser)
     parser.set_defaults(func=main)


### PR DESCRIPTION
In this pull request:

- I removed duplicate code and an empty file to clean up the code.
- I removed unnecessary imports and moved the necessary to the top.
- I adjusted the `common_arg_parser()` function and updated the plug-ins to use it.
- I made `-d` and  `-f` mutually exclusive.
- I added `SNIPPET` as the recognized content type.

In a separate pull request, I would like to unify how plugins handle messages and warnings.