### PR TITLE
Fix EntityReference plugin and update expected files to comply with D…

### DIFF
--- a/asciidoc_dita_toolkit/asciidoc_dita/plugins/EntityReference.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/plugins/EntityReference.py
@@ -43,6 +43,7 @@ ENTITY_TO_ASCIIDOC = {
     "pound": "{pound}",    # £ (pound sign)
     "quot": "{quot}",      # " (quotation mark)
     "raquo": "{raquo}",    # » (right-pointing double angle quotation mark)
+    "rdquo": "{rdquo}",    # " (right double quotation mark)
     "reg": "{reg}",        # ® (registered sign)
     "rsquo": "{rsquo}",    # ’ (right single quotation mark)
     "rsaquo": "{rsaquo}",  # › (single right-pointing angle quotation mark)
@@ -80,13 +81,31 @@ def replace_entities(line):
 def process_file(filepath):
     """
     Process a single .adoc file, replacing entity references.
+    Skip entities within comments (single-line // and block comments ////).
     
     Args:
         filepath: Path to the file to process
     """
     try:
         lines = read_text_preserve_endings(filepath)
-        new_lines = [(replace_entities(text), ending) for text, ending in lines]
+        new_lines = []
+        in_block_comment = False
+        
+        for text, ending in lines:
+            stripped = text.strip()
+            
+            # Check for block comment delimiters
+            if stripped == "////":
+                in_block_comment = not in_block_comment
+                new_lines.append((text, ending))
+                continue
+            
+            # Skip processing if we're in a block comment or it's a single-line comment
+            if in_block_comment or stripped.startswith('//'):
+                new_lines.append((text, ending))
+            else:
+                new_lines.append((replace_entities(text), ending))
+        
         write_text_preserve_endings(filepath, new_lines)
         print(f"Processed {filepath} (preserved per-line endings)")
     except Exception as e:

--- a/tests/fixtures/EntityReference/report_entity_references.expected
+++ b/tests/fixtures/EntityReference/report_entity_references.expected
@@ -1,5 +1,5 @@
 // DITA does not support HTML character entity references:
 
-* &hellip;
-* &middot;
+* {hellip}
+* {middot}
 * ...

--- a/tests/fixtures/EntityReference/report_multiple_references.expected
+++ b/tests/fixtures/EntityReference/report_multiple_references.expected
@@ -1,3 +1,3 @@
 // DITA does not support HTML character entity references:
 
-A &ldquo;character entity reference&rdquo; can appear multiple times on one line and can be _&lsaquo;mixed with other markup&rsaquo;_.
+A {ldquo}character entity reference{rdquo} can appear multiple times on one line and can be _{lsaquo}mixed with other markup{rsaquo}_.

--- a/tests/test_EntityReference.py
+++ b/tests/test_EntityReference.py
@@ -19,8 +19,8 @@ from io import StringIO
 # Add the project root to the path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from asciidoc_dita_toolkit.asciidoc_dita.plugins.EntityReference import replace_entities
-from tests.asciidoc_testkit import run_linewise_test, get_same_dir_fixture_pairs
+from asciidoc_dita_toolkit.asciidoc_dita.plugins.EntityReference import replace_entities, process_file
+from tests.asciidoc_testkit import run_linewise_test, get_same_dir_fixture_pairs, run_file_based_test
 
 FIXTURE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'fixtures', 'EntityReference'))
 
@@ -91,7 +91,13 @@ class TestEntityReference(unittest.TestCase):
             for input_path, expected_path in get_same_dir_fixture_pairs(FIXTURE_DIR):
                 fixture_count += 1
                 with self.subTest(fixture=os.path.basename(input_path)):
-                    success = run_linewise_test(input_path, expected_path, replace_entities)
+                    # Use file-based test for fixtures that contain comments
+                    # (ignore_* fixtures need comment handling)
+                    fixture_name = os.path.basename(input_path)
+                    if fixture_name.startswith('ignore_'):
+                        success = run_file_based_test(input_path, expected_path, process_file)
+                    else:
+                        success = run_linewise_test(input_path, expected_path, replace_entities)
                     self.assertTrue(success, f"Fixture test failed for {input_path}")
             
             if fixture_count > 0:


### PR DESCRIPTION
…ITA 1.3 rule

- Update expected files to replace HTML entities with AsciiDoc attributes
  - report_entity_references.expected: &hellip; → {hellip}, &middot; → {middot}
  - report_multiple_references.expected: &ldquo; → {ldquo}, &rdquo; → {rdquo}, &lsaquo; → {lsaquo}, &rsaquo; → {rsaquo}

- Fix EntityReference plugin to handle comments correctly
  - Add comment detection to skip entities in single-line (//) and block (////) comments
  - Add missing 'rdquo' entity mapping to ENTITY_TO_ASCIIDOC dictionary
  - Implement stateful processing to track block comment boundaries

- Enhance test infrastructure
  - Add run_file_based_test() function for state-dependent transformations
  - Update test_EntityReference.py to use file-based tests for ignore_* fixtures
  - Maintain line-by-line tests for report_* fixtures

- Ensure compliance with DITA 1.3 EntityReference rule:
  - Preserve XML standard entities: &amp;, &lt;, &gt;, &apos;, &quot;
  - Replace all other HTML entities with AsciiDoc attributes: {entityname}
  - Ignore entities within comments

All tests now pass (20/20) and the plugin correctly implements the EntityReference rule from https://github.com/jhradilek/asciidoctor-dita-vale