### PR TITLE
Publish 0.1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test lint format clean install install-dev build publish changelog
+.PHONY: help test lint format clean install install-dev build publish changelog changelog-version release
 
 # Default target
 help:
@@ -11,10 +11,11 @@ help:
 	@echo "  install    - Install package in development mode"
 	@echo "  install-dev - Install package with development dependencies"
 	@echo "  build      - Build distribution packages"
-	@echo "  publish    - Publish to PyPI (requires PYPI_API_TOKEN)"
+	@echo "  publish    - Publish to PyPI (MAINTAINERS ONLY - requires PYPI_API_TOKEN)"
 	@echo "  check      - Run comprehensive quality checks"
 	@echo "  changelog  - Generate changelog entry for latest version"
 	@echo "  changelog-version - Generate changelog for specific version (VERSION=x.y.z)"
+	@echo "  release    - Automated release: bump patch version, commit, tag, push (MAINTAINERS ONLY)(VERSION=x.y.z to override)"
 
 # Test targets
 test:
@@ -92,3 +93,106 @@ changelog-version:
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make changelog-version VERSION=0.1.7"; exit 1; fi
 	@echo "Generating changelog for version $(VERSION)..."
 	./scripts/generate-changelog.sh $(VERSION)
+
+# Release automation target (MAINTAINERS ONLY)
+release: check
+	@echo "Starting automated release process..."
+	@echo "⚠️  WARNING: This target is for project maintainers only!"
+	@echo "   Contributors should not use this target."
+	@echo "   Continue only if you have maintainer access."
+	@echo ""
+	@if [ -z "$(FORCE)" ]; then \
+		echo "Continue as maintainer? (y/N)"; \
+		read -r confirm; \
+		if [ "$$confirm" != "y" ] && [ "$$confirm" != "Y" ]; then \
+			echo "Release cancelled."; \
+			exit 1; \
+		fi; \
+	else \
+		echo "FORCE set, skipping maintainer confirmation."; \
+	fi
+	@# Check if we're on main/master branch
+	@branch=$$(git symbolic-ref --short HEAD); \
+	if [ "$$branch" != "main" ] && [ "$$branch" != "master" ]; then \
+		echo "Error: Release must be done from main/master branch. Current branch: $$branch"; \
+		exit 1; \
+	fi
+	@# Check for uncommitted changes
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: Working directory is not clean. Please commit or stash changes."; \
+		exit 1; \
+	fi
+	@# Check for untracked files that might be important
+	@if [ -n "$$(git status --porcelain | grep '^??')" ]; then \
+		echo "Warning: Untracked files detected. Consider adding them or adding to .gitignore:"; \
+		git status --porcelain | grep '^??'; \
+		if [ -z "$(FORCE)" ]; then \
+			echo "Continue anyway? (y/N)"; \
+			read -r confirm; \
+			if [ "$$confirm" != "y" ] && [ "$$confirm" != "Y" ]; then \
+				echo "Release cancelled."; \
+				exit 1; \
+			fi; \
+		else \
+			echo "FORCE set, skipping untracked files confirmation."; \
+		fi; \
+	fi
+	@# Determine new version
+	@if [ -n "$(VERSION)" ]; then \
+		new_version="$(VERSION)"; \
+		echo "Using specified version: $$new_version"; \
+	else \
+		current_version=$$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/'); \
+		echo "Current version: $$current_version"; \
+		major=$$(echo $$current_version | cut -d. -f1); \
+		minor=$$(echo $$current_version | cut -d. -f2); \
+		patch=$$(echo $$current_version | cut -d. -f3); \
+		new_patch=$$((patch + 1)); \
+		new_version="$$major.$$minor.$$new_patch"; \
+		echo "Auto-bumping patch version to: $$new_version"; \
+	fi; \
+	echo "Proceeding with version: $$new_version"; \
+	if [ -z "$(FORCE)" ]; then \
+		echo "Continue? (y/N)"; \
+		read -r confirm; \
+		if [ "$$confirm" != "y" ] && [ "$$confirm" != "Y" ]; then \
+			echo "Release cancelled."; \
+			exit 1; \
+		fi; \
+	else \
+		echo "FORCE set, skipping version confirmation."; \
+	fi; \
+	release_branch="release/v$$new_version"; \
+	echo "Creating release branch: $$release_branch"; \
+	git checkout -b "$$release_branch"; \
+	echo "Updating version in pyproject.toml..."; \
+	# Portable sed for Linux and macOS
+	if sed --version >/dev/null 2>&1; then \
+		sed -i 's/^version = ".*"/version = "'"$$new_version"'"/' pyproject.toml; \
+	else \
+		sed -i '' 's/^version = ".*"/version = "'"$$new_version"'"/' pyproject.toml; \
+	fi; \
+	echo "Generating changelog for version $$new_version..."; \
+	if [ -f "./scripts/generate-changelog.sh" ]; then \
+		./scripts/generate-changelog.sh $$new_version || true; \
+	else \
+		echo "Changelog script not found, skipping changelog generation."; \
+	fi; \
+	echo "Committing version bump..."; \
+	git add pyproject.toml CHANGELOG.md; \
+	git commit -m "Bump version to $$new_version"; \
+	echo "Pushing release branch..."; \
+	git push origin "$$release_branch"; \
+	echo ""; \
+	echo "🚀 Release branch $$release_branch created and pushed!"; \
+	echo ""; \
+	echo "Next steps:"; \
+	echo "1. Create a Pull Request from $$release_branch to main"; \
+	echo "2. Title: 'Release v$$new_version'"; \
+	echo "3. Once CI passes, merge the PR"; \
+	echo "4. After merging, create and push the tag:"; \
+	echo "   git checkout main"; \
+	echo "   git pull origin main"; \
+	echo "   git tag v$$new_version"; \
+	echo "   git push origin v$$new_version"; \
+	echo "5. GitHub Actions will automatically build and publish to PyPI"

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ changelog-version:
 
 # Release automation target (MAINTAINERS ONLY)
 release: check
+	@set -e
 	@echo "Starting automated release process..."
 	@echo "⚠️  WARNING: This target is for project maintainers only!"
 	@echo "   Contributors should not use this target."

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 	@echo "  check      - Run comprehensive quality checks"
 	@echo "  changelog  - Generate changelog entry for latest version"
 	@echo "  changelog-version - Generate changelog for specific version (VERSION=x.y.z)"
-	@echo "  release    - Automated release: bump patch version, commit, tag, push (MAINTAINERS ONLY)(VERSION=x.y.z to override)"
+	@echo "  release    - Automated release: bump patch version, commit, tag, push (MAINTAINERS ONLY) (VERSION=x.y.z to override)"
 
 # Test targets
 test:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,7 +79,7 @@ make check
 # Build distribution packages
 make build
 
-# Publish to PyPI (requires PYPI_API_TOKEN)
+# Publish to PyPI (MAINTAINERS ONLY - requires PYPI_API_TOKEN)
 make publish
 
 # Clean build artifacts
@@ -222,25 +222,67 @@ To manually update fixtures (rarely needed), you may run the archived script:
 
 ## Publishing a New Release to PyPI
 
-To have the GitHub Actions workflow build and upload the package to PyPI using the `PYPI_API_TOKEN` secret:
+> **Note:** Only project maintainers can publish new releases to PyPI. Contributors with forks can help with development but cannot create official releases.
 
-1. **Update the version** in `pyproject.toml`.
-2. **Commit and push** your changes:
+**Recommended Approach - Automated Release (Maintainers Only):**
+
+Use the new `make release` command for a complete automated workflow:
+
+```sh
+# Automated patch version bump and release
+make release
+
+# Or specify a custom version
+make release VERSION=0.2.0
+```
+
+This will handle version bumping, changelog generation, commits, tagging, and pushing automatically. GitHub Actions will then build and upload the package to PyPI using the `PYPI_API_TOKEN` secret.
+
+**Manual Approach (Maintainers Only):**
+
+To manually have the GitHub Actions workflow build and upload the package to PyPI:
+
+1. **Ensure your main branch is up to date:**
+
+   ```sh
+   git checkout main
+   git pull origin main
+   ```
+
+2. **Create a release preparation branch:**
+
+   ```sh
+   git checkout -b release/v<new-version>  # Example: release/v0.1.8
+   ```
+
+3. **Update the version** in `pyproject.toml`.
+
+4. **Commit your changes and push the branch:**
 
    ```sh
    git add pyproject.toml
    git commit -m "Bump version to <new-version>"
-   git push
+   git push origin release/v<new-version>
    ```
 
-3. **Tag the release and push the tag:**
+5. **Create and merge a Pull Request:**
+   - Open a PR from `release/v<new-version>` to `main`
+   - Title: "Release v\<new-version\>"
+   - Once CI passes, merge the PR (this will update main with the version bump)
+
+6. **Create and push the release tag from main:**
 
    ```sh
-   git tag v<new-version>  # Example: v0.1.3
+   git checkout main
+   git pull origin main
+   
+   git tag v<new-version>  # Example: v0.1.8
    git push origin v<new-version>
    ```
 
-4. GitHub Actions will build and upload the package to PyPI automatically.
+7. GitHub Actions will build and upload the package to PyPI automatically when the tag is pushed.
+
+**Important:** Due to branch protection rules on `main`, all changes (including version bumps) must go through a Pull Request. The tag must be created from the merged commit on `main` to ensure the PyPI release reflects the actual state of the main branch.
 
 ## Troubleshooting if the tagging gets ahead of the version
 
@@ -394,14 +436,35 @@ refactor: improve CLI error handling
 
 ### Release Workflow
 
-**Standard Release Process:**
+**Automated Release Process (Recommended):**
+
+Use the new Makefile `release` target for a fully automated release:
+
+```sh
+# Automated patch version bump (0.1.7 → 0.1.8)
+make release
+
+# Specify custom version
+make release VERSION=0.2.0
+```
+
+**The `make release` command will:**
+
+1. **Validate environment**: Check you're on main/master branch with clean working directory
+2. **Run quality checks**: Execute `make check` (format, lint, test)
+3. **Version management**: Auto-bump patch version or use your specified VERSION
+4. **Update files**: Modify `pyproject.toml` and generate changelog entry
+5. **Git operations**: Commit changes, create tag, push both to origin
+6. **Next steps**: Display instructions for monitoring GitHub Actions
+
+**Manual Release Process (Alternative):**
 
 1. **Development**: Create PRs with descriptive titles and proper labels
 2. **Pre-Release**: Ensure all tests pass and documentation is updated
 3. **Release**: Create GitHub release - changelog updates automatically
 4. **Verification**: Check generated changelog for accuracy
 
-**Example Release Creation:**
+**Example Manual Release Creation:**
 
 ```sh
 # Using GitHub CLI


### PR DESCRIPTION
docs: clarify maintainer-only publishing workflow

Update documentation and tooling to reflect that only the project
maintainers can publish new releases to PyPI:

- Add clear "MAINTAINERS ONLY" notes to publishing sections
- Remove fork-related commands from the release workflow
- Update Makefile release target to work with branch protection
- Simplify manual release steps for maintainer access only
- Add maintainer confirmation prompt to release automation

This ensures the workflow matches repository permissions and
branch protection rules while providing clear guidance for
both contributors and maintainers.