### PR TITLE
Remove command output from from test runs

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,7 @@ class TestCLI(unittest.TestCase):
         """Test handling of plugins missing register_subcommand function."""
         with patch('sys.argv', ['toolkit']), \
              patch('sys.stderr', new_callable=StringIO) as mock_stderr, \
+             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
              patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
              patch('importlib.import_module') as mock_import:
             
@@ -71,6 +72,7 @@ class TestCLI(unittest.TestCase):
         """Test handling of plugin import errors."""
         with patch('sys.argv', ['toolkit']), \
              patch('sys.stderr', new_callable=StringIO) as mock_stderr, \
+             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
              patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
              patch('importlib.import_module', side_effect=ImportError("Test import error")):
             
@@ -83,8 +85,10 @@ class TestCLI(unittest.TestCase):
     @patch('sys.argv', ['toolkit', 'EntityReference', '--help'])
     def test_plugin_help(self):
         """Test that plugin help works correctly."""
-        with self.assertRaises(SystemExit) as cm:
-            toolkit.main()
+
+        with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+            with self.assertRaises(SystemExit) as cm:
+                toolkit.main()
         # argparse exits with code 0 for --help
         self.assertEqual(cm.exception.code, 0)
 


### PR DESCRIPTION
When looking at the test results, I noticed that command output is mixed in the test reports, making it difficult to see the actual problems. This happens both in the `make test` output and in tests ran by GitHub CI:

```
....................
----------------------------------------------------------------------
Ran 20 tests in 0.011s

OK
Warning: Missing ignore_numeric_references.expected file.
Warning: Missing ignore_comments.expected file.
Warning: Missing ignore_supported_entities.expected file.
Warning: Missing report_multiple_references.expected file.
Warning: Missing report_entity_references.expected file.
usage: toolkit EntityReference [-h] [-d DIRECTORY | -f FILE] [-r]

options:
  -h, --help            show this help message and exit
  -d DIRECTORY, --directory DIRECTORY
                        Root directory to search (default: current directory)
  -f FILE, --file FILE  Scan only the specified .adoc file
  -r, --recursive       Search subdirectories recursively
usage: toolkit [-h] [--list-plugins] {} ...

AsciiDoc DITA Toolkit - Process and validate AsciiDoc files for DITA
publishing

positional arguments:
  {}

options:
  -h, --help      show this help message and exit
  --list-plugins  List all available plugins and their descriptions
usage: toolkit [-h] [--list-plugins] {} ...

AsciiDoc DITA Toolkit - Process and validate AsciiDoc files for DITA
publishing

positional arguments:
  {}

options:
  -h, --help      show this help message and exit
  --list-plugins  List all available plugins and their descriptions
```

