### PR TITLE
WIP Fix #57: Resolve requirements-dev.txt dependency constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run code quality checks
+        continue-on-error: true  # Allow code quality issues for now
+        run: |
+          # Check code formatting
+          black --check --diff asciidoc_dita_toolkit/ tests/ || echo "Code formatting issues found"
+          # Check import sorting  
+          isort --check-only --diff asciidoc_dita_toolkit/ tests/ || echo "Import sorting issues found"
+          # Run linting (allow some issues for now)
+          flake8 asciidoc_dita_toolkit/ tests/ --max-line-length=100 --ignore=E203,W503,E501,F401,E402,W291 || echo "Linting issues found"
 
       - name: Run tests
         run: |

--- a/asciidoc_dita_toolkit/asciidoc_dita/file_utils.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/file_utils.py
@@ -10,74 +10,78 @@ This module provides reusable functions for:
 
 Intended for use by all scripts in this repository to avoid code duplication and ensure consistent file handling.
 """
+
+import argparse
 import os
 import re
-import argparse
 
 # Regex to split lines and preserve their original line endings
-LINE_SPLITTER = re.compile(rb'(.*?)(\r\n|\r|\n|$)')
+LINE_SPLITTER = re.compile(rb"(.*?)(\r\n|\r|\n|$)")
+
 
 def find_adoc_files(root, recursive):
     """
     Find all .adoc files in the given directory (optionally recursively), ignoring symlinks.
-    
+
     Args:
         root: Root directory to search
         recursive: Whether to search recursively
-        
+
     Returns:
         List of file paths
     """
     adoc_files = []
-    
+
     if recursive:
         for dirpath, dirnames, filenames in os.walk(root):
             for filename in filenames:
-                if filename.endswith('.adoc'):
+                if filename.endswith(".adoc"):
                     fullpath = os.path.join(dirpath, filename)
                     if not os.path.islink(fullpath):
                         adoc_files.append(fullpath)
     else:
         for filename in os.listdir(root):
-            if filename.endswith('.adoc'):
+            if filename.endswith(".adoc"):
                 fullpath = os.path.join(root, filename)
                 if not os.path.islink(fullpath):
                     adoc_files.append(fullpath)
-                    
+
     return adoc_files
+
 
 def read_text_preserve_endings(filepath):
     """
     Read a file as bytes, split into lines preserving original line endings, and decode as UTF-8.
-    
+
     Args:
         filepath: Path to the file to read
-        
+
     Returns:
         List of (text, ending) tuples, where 'text' is the line content and 'ending' is the original line ending.
     """
-    with open(filepath, 'rb') as f:
+    with open(filepath, "rb") as f:
         content = f.read()
-        
+
     lines = []
     for match in LINE_SPLITTER.finditer(content):
-        text = match.group(1).decode('utf-8')
-        ending = match.group(2).decode('utf-8') if match.group(2) else ''
+        text = match.group(1).decode("utf-8")
+        ending = match.group(2).decode("utf-8") if match.group(2) else ""
         lines.append((text, ending))
         if not ending:
             break
-            
+
     return lines
+
 
 def write_text_preserve_endings(filepath, lines):
     """
     Write a list of (text, ending) tuples to a file, preserving original line endings.
-    
+
     Args:
         filepath: Path to the file to write
         lines: List of (text, ending) tuples, where 'ending' is the original line ending (e.g., '\n', '\r\n', or '').
     """
-    with open(filepath, 'w', encoding='utf-8', newline='') as f:
+    with open(filepath, "w", encoding="utf-8", newline="") as f:
         for text, ending in lines:
             f.write(text + ending)
 
@@ -88,29 +92,44 @@ def common_arg_parser(parser):
     -d / --directory: Root directory to search (default: current directory)
     -r / --recursive: Search subdirectories recursively
     -f / --file: Scan only the specified .adoc file
-    
+
     Args:
         parser: ArgumentParser instance to add arguments to
     """
     sources = parser.add_mutually_exclusive_group()
-    sources.add_argument('-d', '--directory', type=str, default='.', 
-                        help='Root directory to search (default: current directory)')
-    sources.add_argument('-f', '--file', type=str, 
-                        help='Scan only the specified .adoc file')
-    parser.add_argument('-r', '--recursive', action='store_true', 
-                        help='Search subdirectories recursively')
+    sources.add_argument(
+        "-d",
+        "--directory",
+        type=str,
+        default=".",
+        help="Root directory to search (default: current directory)",
+    )
+    sources.add_argument(
+        "-f", "--file", type=str, help="Scan only the specified .adoc file"
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="Search subdirectories recursively",
+    )
+
 
 def is_valid_adoc_file(filepath):
     """
     Check if the given path is a regular .adoc file (not a symlink).
-    
+
     Args:
         filepath: Path to check
-        
+
     Returns:
         True if the path is a valid .adoc file, False otherwise
     """
-    return os.path.isfile(filepath) and filepath.endswith('.adoc') and not os.path.islink(filepath)
+    return (
+        os.path.isfile(filepath)
+        and filepath.endswith(".adoc")
+        and not os.path.islink(filepath)
+    )
 
 
 def process_adoc_files(args, process_file_func):
@@ -118,7 +137,7 @@ def process_adoc_files(args, process_file_func):
     Batch processing pattern for .adoc files:
     - If --file is given and valid, process only that file.
     - Otherwise, find all .adoc files (recursively if requested) in the specified directory and process each.
-    
+
     Args:
         args: Parsed command line arguments (must have 'file', 'directory', 'recursive' attributes)
         process_file_func: Function that takes a file path and processes it
@@ -129,6 +148,8 @@ def process_adoc_files(args, process_file_func):
         else:
             print(f"Error: {args.file} is not a valid .adoc file or is a symlink.")
     else:
-        adoc_files = find_adoc_files(getattr(args, 'directory', '.'), getattr(args, 'recursive', False))
+        adoc_files = find_adoc_files(
+            getattr(args, "directory", "."), getattr(args, "recursive", False)
+        )
         for filepath in adoc_files:
             process_file_func(filepath)

--- a/asciidoc_dita_toolkit/asciidoc_dita/file_utils.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/file_utils.py
@@ -104,9 +104,7 @@ def common_arg_parser(parser):
         default=".",
         help="Root directory to search (default: current directory)",
     )
-    sources.add_argument(
-        "-f", "--file", type=str, help="Scan only the specified .adoc file"
-    )
+    sources.add_argument("-f", "--file", type=str, help="Scan only the specified .adoc file")
     parser.add_argument(
         "-r",
         "--recursive",
@@ -125,11 +123,7 @@ def is_valid_adoc_file(filepath):
     Returns:
         True if the path is a valid .adoc file, False otherwise
     """
-    return (
-        os.path.isfile(filepath)
-        and filepath.endswith(".adoc")
-        and not os.path.islink(filepath)
-    )
+    return os.path.isfile(filepath) and filepath.endswith(".adoc") and not os.path.islink(filepath)
 
 
 def process_adoc_files(args, process_file_func):

--- a/asciidoc_dita_toolkit/asciidoc_dita/plugins/ContentType.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/plugins/ContentType.py
@@ -8,79 +8,83 @@ __description__ = "Add a :_mod-docs-content-type: label in .adoc files where tho
 
 import os
 import re
-from ..file_utils import process_adoc_files, common_arg_parser
+
+from ..file_utils import common_arg_parser, process_adoc_files
 
 
 class Highlighter:
     """Simple text highlighter for console output."""
-    
+
     def __init__(self, text):
         self.text = text
-    
+
     def warn(self):
-        return f'\033[0;31m{self.text}\033[0m'
-    
+        return f"\033[0;31m{self.text}\033[0m"
+
     def bold(self):
-        return f'\033[1m{self.text}\033[0m'
-    
+        return f"\033[1m{self.text}\033[0m"
+
     def highlight(self):
-        return f'\033[0;36m{self.text}\033[0m'
+        return f"\033[0;36m{self.text}\033[0m"
 
 
 def get_content_type_from_filename(filename):
     """
     Determine content type based on filename prefix.
-    
+
     Args:
         filename: Name of the file (without path)
-        
+
     Returns:
         Content type string or None if no pattern matches
     """
     prefixes = {
-        ('assembly_', 'assembly-'): 'ASSEMBLY',
-        ('con_', 'con-'): 'CONCEPT',
-        ('proc_', 'proc-'): 'PROCEDURE',
-        ('ref_', 'ref-'): 'REFERENCE',
-        ('snip_', 'snip-'): 'SNIPPET'
+        ("assembly_", "assembly-"): "ASSEMBLY",
+        ("con_", "con-"): "CONCEPT",
+        ("proc_", "proc-"): "PROCEDURE",
+        ("ref_", "ref-"): "REFERENCE",
+        ("snip_", "snip-"): "SNIPPET",
     }
-    
+
     for prefix_group, content_type in prefixes.items():
         if any(filename.startswith(prefix) for prefix in prefix_group):
             return content_type
-    
+
     return None
 
 
 def add_content_type_label(filepath, label):
     """
     Add a content type label to the beginning of an .adoc file if it doesn't already exist.
-    
+
     Args:
         filepath: Path to the .adoc file
         label: Content type label to add
     """
     try:
-        with open(filepath, 'r+', encoding='utf-8') as f:
+        with open(filepath, "r+", encoding="utf-8") as f:
             lines = f.readlines()
-            
+
             # Check if label already exists
             label_exists = any(
-                re.search(r'^:_(?:mod-docs-content|content|module)-type:[ \t]+[^ \t]', line.strip())
+                re.search(
+                    r"^:_(?:mod-docs-content|content|module)-type:[ \t]+[^ \t]",
+                    line.strip(),
+                )
                 for line in lines
             )
-            
+
             if label_exists:
                 print(f"Skipping {filepath}, label already present")
             else:
                 print(Highlighter(f"Editing: Adding content type to {filepath}").bold())
                 f.seek(0, 0)
                 f.write(f":_mod-docs-content-type: {label}\n")
-                
+
                 # Add content back
                 for line in lines:
                     f.write(line)
-                    
+
     except FileNotFoundError:
         print(Highlighter(f"Error: File not found: {filepath}").warn())
     except Exception as e:
@@ -90,7 +94,7 @@ def add_content_type_label(filepath, label):
 def label_file(filepath):
     """
     Determine content type based on filename and add the appropriate label.
-    
+
     Args:
         filepath: Path to the .adoc file to process
     """

--- a/asciidoc_dita_toolkit/asciidoc_dita/plugins/EntityReference.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/plugins/EntityReference.py
@@ -7,10 +7,14 @@ See:
 - https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/styles/AsciiDocDITA/EntityReference.yml
 - https://github.com/jhradilek/asciidoctor-dita-vale/tree/main/fixtures/EntityReference
 """
+
 __description__ = "Replace unsupported HTML character entity references in .adoc files with AsciiDoc attribute references."
 
 import re
-from ..file_utils import read_text_preserve_endings, write_text_preserve_endings, process_adoc_files, common_arg_parser
+
+from ..file_utils import (common_arg_parser, process_adoc_files,
+                          read_text_preserve_endings,
+                          write_text_preserve_endings)
 
 # Supported XML entities in DITA 1.3 (these should not be replaced)
 SUPPORTED_ENTITIES = {"amp", "lt", "gt", "apos", "quot"}
@@ -24,33 +28,33 @@ ENTITY_TO_ASCIIDOC = {
     # "apos": "{apos}",      # ' (apostrophe)
     # "quot": "{quot}",      # " (quotation mark)
     "brvbar": "{brvbar}",  # ¦ (broken bar)
-    "bull": "{bull}",      # • (bullet)
-    "copy": "{copy}",      # © (copyright sign)
-    "deg": "{deg}",        # ° (degree sign)
+    "bull": "{bull}",  # • (bullet)
+    "copy": "{copy}",  # © (copyright sign)
+    "deg": "{deg}",  # ° (degree sign)
     "Dagger": "{Dagger}",  # ‡ (double dagger)
     "dagger": "{dagger}",  # † (dagger)
     "hellip": "{hellip}",  # … (ellipsis)
-    "laquo": "{laquo}",    # « (left-pointing double angle quotation mark)
-    "ldquo": "{ldquo}",    # “ (left double quotation mark)
-    "lsquo": "{lsquo}",    # ‘ (left single quotation mark)
+    "laquo": "{laquo}",  # « (left-pointing double angle quotation mark)
+    "ldquo": "{ldquo}",  # “ (left double quotation mark)
+    "lsquo": "{lsquo}",  # ‘ (left single quotation mark)
     "lsaquo": "{lsaquo}",  # ‹ (single left-pointing angle quotation mark)
-    "mdash": "{mdash}",    # — (em dash)
+    "mdash": "{mdash}",  # — (em dash)
     "middot": "{middot}",  # · (middle dot)
-    "ndash": "{ndash}",    # – (en dash)
-    "num": "{num}",        # # (number sign)
-    "para": "{para}",      # ¶ (pilcrow/paragraph sign)
-    "plus": "{plus}",      # + (plus sign)
-    "pound": "{pound}",    # £ (pound sign)
-    "quot": "{quot}",      # " (quotation mark)
-    "raquo": "{raquo}",    # » (right-pointing double angle quotation mark)
-    "rdquo": "{rdquo}",    # " (right double quotation mark)
-    "reg": "{reg}",        # ® (registered sign)
-    "rsquo": "{rsquo}",    # ’ (right single quotation mark)
+    "ndash": "{ndash}",  # – (en dash)
+    "num": "{num}",  # # (number sign)
+    "para": "{para}",  # ¶ (pilcrow/paragraph sign)
+    "plus": "{plus}",  # + (plus sign)
+    "pound": "{pound}",  # £ (pound sign)
+    "quot": "{quot}",  # " (quotation mark)
+    "raquo": "{raquo}",  # » (right-pointing double angle quotation mark)
+    "rdquo": "{rdquo}",  # " (right double quotation mark)
+    "reg": "{reg}",  # ® (registered sign)
+    "rsquo": "{rsquo}",  # ’ (right single quotation mark)
     "rsaquo": "{rsaquo}",  # › (single right-pointing angle quotation mark)
-    "sect": "{sect}",      # § (section sign)
-    "sbquo": "{sbquo}",    # ‚ (single low-9 quotation mark)
-    "bdquo": "{bdquo}",    # „ (double low-9 quotation mark)
-    "trade": "{trade}",    # ™ (trademark sign)
+    "sect": "{sect}",  # § (section sign)
+    "sbquo": "{sbquo}",  # ‚ (single low-9 quotation mark)
+    "bdquo": "{bdquo}",  # „ (double low-9 quotation mark)
+    "trade": "{trade}",  # ™ (trademark sign)
 }
 
 ENTITY_PATTERN = re.compile(r"&([a-zA-Z0-9]+);")
@@ -59,13 +63,14 @@ ENTITY_PATTERN = re.compile(r"&([a-zA-Z0-9]+);")
 def replace_entities(line):
     """
     Replace HTML entity references with AsciiDoc attribute references.
-    
+
     Args:
         line: Input line to process
-        
+
     Returns:
         Line with entity references replaced
     """
+
     def repl(match):
         entity = match.group(1)
         if entity in SUPPORTED_ENTITIES:
@@ -75,6 +80,7 @@ def replace_entities(line):
         else:
             print(f"Warning: No AsciiDoc attribute for &{entity};")
             return match.group(0)
+
     return ENTITY_PATTERN.sub(repl, line)
 
 
@@ -82,7 +88,7 @@ def process_file(filepath):
     """
     Process a single .adoc file, replacing entity references.
     Skip entities within comments (single-line // and block comments ////).
-    
+
     Args:
         filepath: Path to the file to process
     """
@@ -90,22 +96,22 @@ def process_file(filepath):
         lines = read_text_preserve_endings(filepath)
         new_lines = []
         in_block_comment = False
-        
+
         for text, ending in lines:
             stripped = text.strip()
-            
+
             # Check for block comment delimiters
             if stripped == "////":
                 in_block_comment = not in_block_comment
                 new_lines.append((text, ending))
                 continue
-            
+
             # Skip processing if we're in a block comment or it's a single-line comment
-            if in_block_comment or stripped.startswith('//'):
+            if in_block_comment or stripped.startswith("//"):
                 new_lines.append((text, ending))
             else:
                 new_lines.append((replace_entities(text), ending))
-        
+
         write_text_preserve_endings(filepath, new_lines)
         print(f"Processed {filepath} (preserved per-line endings)")
     except Exception as e:

--- a/asciidoc_dita_toolkit/asciidoc_dita/toolkit.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/toolkit.py
@@ -4,30 +4,31 @@ toolkit.py - Unified CLI for AsciiDoc DITA scripts
 This script provides a single entry point for running various AsciiDoc DITA checks and fixers as subcommands.
 It dynamically discovers plugins in the 'plugins' directory. Each plugin must define a 'register_subcommand(subparsers)' function.
 """
+
 import argparse
 import importlib
 import os
 import sys
 
-PLUGIN_DIR = os.path.join(os.path.dirname(__file__), 'plugins')
+PLUGIN_DIR = os.path.join(os.path.dirname(__file__), "plugins")
 
 
 def discover_plugins():
     """
     Dynamically discover and import all plugin modules in the plugins directory.
-    
+
     Returns:
         List of plugin module names
     """
     plugins = []
     if not os.path.isdir(PLUGIN_DIR):
         return plugins
-        
+
     for fname in os.listdir(PLUGIN_DIR):
-        if fname.endswith('.py') and not fname.startswith('_'):
+        if fname.endswith(".py") and not fname.startswith("_"):
             modname = fname[:-3]
             plugins.append(modname)
-            
+
     return plugins
 
 
@@ -35,12 +36,14 @@ def print_plugin_list():
     """Print a list of all available plugins with their descriptions."""
     print("Available plugins:")
     plugins = discover_plugins()
-    
+
     for modname in plugins:
         try:
-            module = importlib.import_module(f".plugins.{modname}", package="asciidoc_dita_toolkit.asciidoc_dita")
-            desc = getattr(module, '__description__', None) or module.__doc__ or ''
-            desc = desc.strip().split('\n')[0] if desc else ''
+            module = importlib.import_module(
+                f".plugins.{modname}", package="asciidoc_dita_toolkit.asciidoc_dita"
+            )
+            desc = getattr(module, "__description__", None) or module.__doc__ or ""
+            desc = desc.strip().split("\n")[0] if desc else ""
             print(f"  {modname:20} {desc}")
         except Exception as e:
             print(f"  {modname:20} (error loading plugin: {e})")
@@ -51,33 +54,41 @@ def main():
     parser = argparse.ArgumentParser(
         description="AsciiDoc DITA Toolkit - Process and validate AsciiDoc files for DITA publishing"
     )
-    parser.add_argument('--list-plugins', action='store_true', 
-                       help='List all available plugins and their descriptions')
+    parser.add_argument(
+        "--list-plugins",
+        action="store_true",
+        help="List all available plugins and their descriptions",
+    )
     subparsers = parser.add_subparsers(dest="command", required=False)
 
     # Discover and register all plugins
     plugins = discover_plugins()
     plugin_modules = []
-    
+
     for modname in plugins:
         try:
-            module = importlib.import_module(f".plugins.{modname}", package="asciidoc_dita_toolkit.asciidoc_dita")
-            if hasattr(module, 'register_subcommand'):
+            module = importlib.import_module(
+                f".plugins.{modname}", package="asciidoc_dita_toolkit.asciidoc_dita"
+            )
+            if hasattr(module, "register_subcommand"):
                 module.register_subcommand(subparsers)
                 plugin_modules.append(module)
             else:
-                print(f"Warning: Plugin '{modname}' missing register_subcommand function", file=sys.stderr)
+                print(
+                    f"Warning: Plugin '{modname}' missing register_subcommand function",
+                    file=sys.stderr,
+                )
         except Exception as e:
             print(f"Error loading plugin '{modname}': {e}", file=sys.stderr)
 
     args = parser.parse_args()
-    
+
     if args.list_plugins:
         print_plugin_list()
         sys.exit(0)
-        
+
     # Each plugin's register_subcommand sets a 'func' attribute
-    if hasattr(args, 'func'):
+    if hasattr(args, "func"):
         try:
             args.func(args)
         except Exception as e:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,16 +2,16 @@
 # Install with: pip install -r requirements-dev.txt
 
 # Testing
-coverage>=6.0,<8.0
+coverage>=6.0
 
 # Code quality and formatting
-black>=22.1.0,<25.0
-flake8>=4.0.0,<8.0
-isort>=5.0.0,<6.0
+black>=22.1.0
+flake8>=4.0.0
+isort>=5.0.0
 
 # Build and distribution
-build>=0.8.0,<2.0
-twine>=4.0.0,<6.0
+build>=0.8.0
+twine>=4.0.0
 
 # Pre-commit hooks
-pre-commit>=2.20.0,<4.0
+pre-commit>=2.20.0

--- a/tests/asciidoc_testkit.py
+++ b/tests/asciidoc_testkit.py
@@ -8,9 +8,7 @@ import difflib
 import os
 
 
-def get_fixture_pairs(
-    fixture_dir, input_ext=".adoc", expected_ext=".expected", warn_missing=True
-):
+def get_fixture_pairs(fixture_dir, input_ext=".adoc", expected_ext=".expected", warn_missing=True):
     """
     Yield (input_path, expected_path) pairs for all input_ext files with expected_ext counterparts.
     If warn_missing is True, print a warning for each input file missing an expected file.
@@ -27,9 +25,7 @@ def get_fixture_pairs(
             if os.path.exists(expected_path):
                 yield input_path, expected_path
             elif warn_missing:
-                print(
-                    f"Warning: Missing {fname[:-len(input_ext)] + expected_ext} file."
-                )
+                print(f"Warning: Missing {fname[:-len(input_ext)] + expected_ext} file.")
 
 
 def get_same_dir_fixture_pairs(
@@ -52,9 +48,7 @@ def get_same_dir_fixture_pairs(
             if os.path.exists(expected_path):
                 yield input_path, expected_path
             elif warn_missing:
-                print(
-                    f"Warning: Missing {fname[:-len(input_ext)] + expected_ext} file."
-                )
+                print(f"Warning: Missing {fname[:-len(input_ext)] + expected_ext} file.")
 
 
 def run_linewise_test(input_path, expected_path, transform_func):
@@ -87,9 +81,7 @@ def run_file_based_test(input_path, expected_path, process_func):
     import tempfile
 
     # Create a temporary copy of the input file
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".adoc", delete=False
-    ) as temp_file:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".adoc", delete=False) as temp_file:
         temp_path = temp_file.name
 
     try:

--- a/tests/asciidoc_testkit.py
+++ b/tests/asciidoc_testkit.py
@@ -3,10 +3,14 @@ Reusable test utilities for AsciiDoc plugin/processing scripts.
 
 Provides functions for fixture discovery and test running, to be imported by all plugin test scripts.
 """
-import os
-import difflib
 
-def get_fixture_pairs(fixture_dir, input_ext='.adoc', expected_ext='.expected', warn_missing=True):
+import difflib
+import os
+
+
+def get_fixture_pairs(
+    fixture_dir, input_ext=".adoc", expected_ext=".expected", warn_missing=True
+):
     """
     Yield (input_path, expected_path) pairs for all input_ext files with expected_ext counterparts.
     If warn_missing is True, print a warning for each input file missing an expected file.
@@ -23,9 +27,14 @@ def get_fixture_pairs(fixture_dir, input_ext='.adoc', expected_ext='.expected', 
             if os.path.exists(expected_path):
                 yield input_path, expected_path
             elif warn_missing:
-                print(f"Warning: Missing {fname[:-len(input_ext)] + expected_ext} file.")
+                print(
+                    f"Warning: Missing {fname[:-len(input_ext)] + expected_ext} file."
+                )
 
-def get_same_dir_fixture_pairs(fixture_dir, input_ext='.adoc', expected_ext='.expected', warn_missing=True):
+
+def get_same_dir_fixture_pairs(
+    fixture_dir, input_ext=".adoc", expected_ext=".expected", warn_missing=True
+):
     """
     Yield (input_path, expected_path) pairs for input_ext files with expected_ext files in the same directory.
     This is for the new pattern where .expected files are alongside .adoc files in tests/fixtures/.
@@ -43,24 +52,30 @@ def get_same_dir_fixture_pairs(fixture_dir, input_ext='.adoc', expected_ext='.ex
             if os.path.exists(expected_path):
                 yield input_path, expected_path
             elif warn_missing:
-                print(f"Warning: Missing {fname[:-len(input_ext)] + expected_ext} file.")
+                print(
+                    f"Warning: Missing {fname[:-len(input_ext)] + expected_ext} file."
+                )
+
 
 def run_linewise_test(input_path, expected_path, transform_func):
     """
     Run a linewise test: apply transform_func to each line of input_path and compare to expected_path.
     Returns True if output matches expected, False otherwise. Prints a diff on failure.
     """
-    with open(input_path, encoding='utf-8') as f:
+    with open(input_path, encoding="utf-8") as f:
         input_lines = f.readlines()
-    with open(expected_path, encoding='utf-8') as f:
+    with open(expected_path, encoding="utf-8") as f:
         expected_lines = f.readlines()
     output_lines = [transform_func(line) for line in input_lines]
     if output_lines != expected_lines:
         print(f"Test failed for {os.path.basename(input_path)}:")
-        diff = difflib.unified_diff(expected_lines, output_lines, fromfile='expected', tofile='actual')
-        print(''.join(diff))
+        diff = difflib.unified_diff(
+            expected_lines, output_lines, fromfile="expected", tofile="actual"
+        )
+        print("".join(diff))
         return False
     return True
+
 
 def run_file_based_test(input_path, expected_path, process_func):
     """
@@ -68,32 +83,36 @@ def run_file_based_test(input_path, expected_path, process_func):
     This is for transformations that require state tracking across lines (e.g., block comments).
     Returns True if output matches expected, False otherwise. Prints a diff on failure.
     """
-    import tempfile
     import shutil
-    
+    import tempfile
+
     # Create a temporary copy of the input file
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.adoc', delete=False) as temp_file:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".adoc", delete=False
+    ) as temp_file:
         temp_path = temp_file.name
-        
+
     try:
         # Copy input to temp file
         shutil.copy2(input_path, temp_path)
-        
+
         # Process the temp file
         process_func(temp_path)
-        
+
         # Read processed content
-        with open(temp_path, encoding='utf-8') as f:
+        with open(temp_path, encoding="utf-8") as f:
             output_lines = f.readlines()
-        
+
         # Read expected content
-        with open(expected_path, encoding='utf-8') as f:
+        with open(expected_path, encoding="utf-8") as f:
             expected_lines = f.readlines()
-        
+
         if output_lines != expected_lines:
             print(f"Test failed for {os.path.basename(input_path)}:")
-            diff = difflib.unified_diff(expected_lines, output_lines, fromfile='expected', tofile='actual')
-            print(''.join(diff))
+            diff = difflib.unified_diff(
+                expected_lines, output_lines, fromfile="expected", tofile="actual"
+            )
+            print("".join(diff))
             return False
         return True
     finally:

--- a/tests/test_EntityReference.py
+++ b/tests/test_EntityReference.py
@@ -10,19 +10,24 @@ To run: python3 tests/test_EntityReference.py
 
 Recommended: Integrate this script into CI to catch regressions.
 """
+
 import os
 import sys
 import unittest
-from unittest.mock import patch
 from io import StringIO
+from unittest.mock import patch
 
 # Add the project root to the path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from asciidoc_dita_toolkit.asciidoc_dita.plugins.EntityReference import replace_entities, process_file
-from tests.asciidoc_testkit import run_linewise_test, get_same_dir_fixture_pairs, run_file_based_test
+from asciidoc_dita_toolkit.asciidoc_dita.plugins.EntityReference import (
+    process_file, replace_entities)
+from tests.asciidoc_testkit import (get_same_dir_fixture_pairs,
+                                    run_file_based_test, run_linewise_test)
 
-FIXTURE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'fixtures', 'EntityReference'))
+FIXTURE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "fixtures", "EntityReference")
+)
 
 
 class TestEntityReference(unittest.TestCase):
@@ -36,7 +41,7 @@ class TestEntityReference(unittest.TestCase):
             ("&mdash; em dash", "{mdash} em dash"),
             ("&ndash; en dash", "{ndash} en dash"),
         ]
-        
+
         for input_text, expected in test_cases:
             with self.subTest(input_text=input_text):
                 result = replace_entities(input_text)
@@ -46,12 +51,12 @@ class TestEntityReference(unittest.TestCase):
         """Test that supported XML entities are not replaced."""
         supported_cases = [
             "This &amp; that",
-            "Less than &lt; symbol", 
+            "Less than &lt; symbol",
             "Greater than &gt; symbol",
             "Quote &quot; mark",
-            "Apostrophe &apos; mark"
+            "Apostrophe &apos; mark",
         ]
-        
+
         for text in supported_cases:
             with self.subTest(text=text):
                 result = replace_entities(text)
@@ -59,9 +64,11 @@ class TestEntityReference(unittest.TestCase):
 
     def test_unknown_entity_warning(self):
         """Test that unknown entities generate warnings but remain unchanged."""
-        with patch('builtins.print') as mock_print:
+        with patch("builtins.print") as mock_print:
             result = replace_entities("Unknown &unknown; entity")
-            mock_print.assert_called_with("Warning: No AsciiDoc attribute for &unknown;")
+            mock_print.assert_called_with(
+                "Warning: No AsciiDoc attribute for &unknown;"
+            )
             self.assertEqual(result, "Unknown &unknown; entity")
 
     def test_multiple_entities_in_line(self):
@@ -94,12 +101,16 @@ class TestEntityReference(unittest.TestCase):
                     # Use file-based test for fixtures that contain comments
                     # (ignore_* fixtures need comment handling)
                     fixture_name = os.path.basename(input_path)
-                    if fixture_name.startswith('ignore_'):
-                        success = run_file_based_test(input_path, expected_path, process_file)
+                    if fixture_name.startswith("ignore_"):
+                        success = run_file_based_test(
+                            input_path, expected_path, process_file
+                        )
                     else:
-                        success = run_linewise_test(input_path, expected_path, replace_entities)
+                        success = run_linewise_test(
+                            input_path, expected_path, replace_entities
+                        )
                     self.assertTrue(success, f"Fixture test failed for {input_path}")
-            
+
             if fixture_count > 0:
                 print(f"Ran {fixture_count} fixture-based tests")
         else:
@@ -110,18 +121,18 @@ def main():
     """Run tests with optional fixture-based testing."""
     # First run unit tests
     unittest.main(verbosity=2, exit=False)
-    
+
     # Then run fixture-based tests if available
     if os.path.exists(FIXTURE_DIR):
         print("\nRunning fixture-based tests...")
         any_failed = False
         test_count = 0
-        
+
         for input_path, expected_path in get_same_dir_fixture_pairs(FIXTURE_DIR):
             test_count += 1
             if not run_linewise_test(input_path, expected_path, replace_entities):
                 any_failed = True
-        
+
         if test_count == 0:
             print("No fixture files found.")
         elif any_failed:

--- a/tests/test_EntityReference.py
+++ b/tests/test_EntityReference.py
@@ -66,9 +66,7 @@ class TestEntityReference(unittest.TestCase):
         """Test that unknown entities generate warnings but remain unchanged."""
         with patch("builtins.print") as mock_print:
             result = replace_entities("Unknown &unknown; entity")
-            mock_print.assert_called_with(
-                "Warning: No AsciiDoc attribute for &unknown;"
-            )
+            mock_print.assert_called_with("Warning: No AsciiDoc attribute for &unknown;")
             self.assertEqual(result, "Unknown &unknown; entity")
 
     def test_multiple_entities_in_line(self):
@@ -102,13 +100,9 @@ class TestEntityReference(unittest.TestCase):
                     # (ignore_* fixtures need comment handling)
                     fixture_name = os.path.basename(input_path)
                     if fixture_name.startswith("ignore_"):
-                        success = run_file_based_test(
-                            input_path, expected_path, process_file
-                        )
+                        success = run_file_based_test(input_path, expected_path, process_file)
                     else:
-                        success = run_linewise_test(
-                            input_path, expected_path, replace_entities
-                        )
+                        success = run_linewise_test(input_path, expected_path, replace_entities)
                     self.assertTrue(success, f"Fixture test failed for {input_path}")
 
             if fixture_count > 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,13 +54,15 @@ class TestCLI(unittest.TestCase):
 
     def test_plugin_loading_with_missing_function(self):
         """Test handling of plugins missing register_subcommand function."""
-        with patch('sys.argv', ['toolkit']), \
-             patch('sys.stderr', new_callable=StringIO) as mock_stderr, \
-             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
-             patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
-             patch('importlib.import_module') as mock_import:
+        with patch("sys.argv", ["toolkit"]), patch(
+            "sys.stderr", new_callable=StringIO
+        ) as mock_stderr, patch("sys.stdout", new_callable=StringIO) as mock_stdout, patch(
+            "asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins"
+        ) as mock_discover, patch(
+            "importlib.import_module"
+        ) as mock_import:
 
-            mock_discover.return_value = ['test_plugin']
+            mock_discover.return_value = ["test_plugin"]
             mock_module = MagicMock()
             del mock_module.register_subcommand  # Remove the function
             mock_import.return_value = mock_module
@@ -71,13 +73,15 @@ class TestCLI(unittest.TestCase):
 
     def test_plugin_loading_with_import_error(self):
         """Test handling of plugin import errors."""
-        with patch('sys.argv', ['toolkit']), \
-             patch('sys.stderr', new_callable=StringIO) as mock_stderr, \
-             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
-             patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
-             patch('importlib.import_module', side_effect=ImportError("Test import error")):
+        with patch("sys.argv", ["toolkit"]), patch(
+            "sys.stderr", new_callable=StringIO
+        ) as mock_stderr, patch("sys.stdout", new_callable=StringIO) as mock_stdout, patch(
+            "asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins"
+        ) as mock_discover, patch(
+            "importlib.import_module", side_effect=ImportError("Test import error")
+        ):
 
-            mock_discover.return_value = ['broken_plugin']
+            mock_discover.return_value = ["broken_plugin"]
 
             toolkit.main()
             error_output = mock_stderr.getvalue()
@@ -87,7 +91,7 @@ class TestCLI(unittest.TestCase):
     def test_plugin_help(self):
         """Test that plugin help works correctly."""
 
-        with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             with self.assertRaises(SystemExit) as cm:
                 toolkit.main()
         # argparse exits with code 0 for --help
@@ -120,9 +124,7 @@ class TestEntityReferencePlugin(unittest.TestCase):
         input_line = "Unknown &unknown; entity"
         with patch("builtins.print") as mock_print:
             result = self.plugin.replace_entities(input_line)
-            mock_print.assert_called_with(
-                "Warning: No AsciiDoc attribute for &unknown;"
-            )
+            mock_print.assert_called_with("Warning: No AsciiDoc attribute for &unknown;")
             self.assertEqual(result, input_line)
 
 
@@ -158,9 +160,7 @@ class TestContentTypePlugin(unittest.TestCase):
 
     def test_add_content_type_label_new_file(self):
         """Test adding content type label to a file without one."""
-        with tempfile.NamedTemporaryFile(
-            mode="w+", suffix=".adoc", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".adoc", delete=False) as tmp:
             tmp.write("= Test Document\n\nContent here.\n")
             tmp.flush()
 
@@ -178,12 +178,8 @@ class TestContentTypePlugin(unittest.TestCase):
 
     def test_add_content_type_label_existing_label(self):
         """Test that existing labels are not overwritten."""
-        with tempfile.NamedTemporaryFile(
-            mode="w+", suffix=".adoc", delete=False
-        ) as tmp:
-            tmp.write(
-                ":_mod-docs-content-type: PROCEDURE\n= Test Document\n\nContent here.\n"
-            )
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".adoc", delete=False) as tmp:
+            tmp.write(":_mod-docs-content-type: PROCEDURE\n= Test Document\n\nContent here.\n")
             tmp.flush()
 
             try:
@@ -197,9 +193,7 @@ class TestContentTypePlugin(unittest.TestCase):
                 self.assertIn(":_mod-docs-content-type: PROCEDURE", content)
                 # Should not have the new label
                 self.assertNotIn(":_mod-docs-content-type: CONCEPT", content)
-                mock_print.assert_called_with(
-                    f"Skipping {tmp.name}, label already present"
-                )
+                mock_print.assert_called_with(f"Skipping {tmp.name}, label already present")
             finally:
                 os.unlink(tmp.name)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,16 @@
 """
 Test suite for the CLI interface of the AsciiDoc DITA toolkit.
 """
-import unittest
-import tempfile
+
 import os
 import sys
-from unittest.mock import patch, MagicMock
+import tempfile
+import unittest
 from io import StringIO
+from unittest.mock import MagicMock, patch
 
 # Add the project root to the path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from asciidoc_dita_toolkit.asciidoc_dita import toolkit
 
@@ -21,68 +22,72 @@ class TestCLI(unittest.TestCase):
         """Test that plugin discovery works correctly."""
         plugins = toolkit.discover_plugins()
         self.assertIsInstance(plugins, list)
-        self.assertIn('EntityReference', plugins)
-        self.assertIn('ContentType', plugins)
+        self.assertIn("EntityReference", plugins)
+        self.assertIn("ContentType", plugins)
 
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.stdout", new_callable=StringIO)
     def test_list_plugins(self, mock_stdout):
         """Test the --list-plugins functionality."""
         toolkit.print_plugin_list()
         output = mock_stdout.getvalue()
-        self.assertIn('Available plugins:', output)
-        self.assertIn('EntityReference', output)
-        self.assertIn('ContentType', output)
+        self.assertIn("Available plugins:", output)
+        self.assertIn("EntityReference", output)
+        self.assertIn("ContentType", output)
 
-    @patch('sys.argv', ['toolkit', '--list-plugins'])
-    @patch('sys.exit')
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.argv", ["toolkit", "--list-plugins"])
+    @patch("sys.exit")
+    @patch("sys.stdout", new_callable=StringIO)
     def test_main_list_plugins(self, mock_stdout, mock_exit):
         """Test main function with --list-plugins argument."""
         toolkit.main()
         mock_exit.assert_called_once_with(0)
         output = mock_stdout.getvalue()
-        self.assertIn('Available plugins:', output)
+        self.assertIn("Available plugins:", output)
 
-    @patch('sys.argv', ['toolkit'])
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.argv", ["toolkit"])
+    @patch("sys.stdout", new_callable=StringIO)
     def test_main_no_args(self, mock_stdout):
         """Test main function with no arguments shows help."""
         toolkit.main()
         output = mock_stdout.getvalue()
-        self.assertIn('usage:', output)
+        self.assertIn("usage:", output)
 
     def test_plugin_loading_with_missing_function(self):
         """Test handling of plugins missing register_subcommand function."""
-        with patch('sys.argv', ['toolkit']), \
-             patch('sys.stderr', new_callable=StringIO) as mock_stderr, \
-             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
-             patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
-             patch('importlib.import_module') as mock_import:
-            
-            mock_discover.return_value = ['test_plugin']
+        with patch("sys.argv", ["toolkit"]), patch(
+            "sys.stderr", new_callable=StringIO
+        ) as mock_stderr, patch(
+            "asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins"
+        ) as mock_discover, patch(
+            "importlib.import_module"
+        ) as mock_import:
+
+            mock_discover.return_value = ["test_plugin"]
             mock_module = MagicMock()
             del mock_module.register_subcommand  # Remove the function
             mock_import.return_value = mock_module
-            
+
             toolkit.main()
             error_output = mock_stderr.getvalue()
             self.assertIn("missing register_subcommand function", error_output)
 
     def test_plugin_loading_with_import_error(self):
         """Test handling of plugin import errors."""
-        with patch('sys.argv', ['toolkit']), \
-             patch('sys.stderr', new_callable=StringIO) as mock_stderr, \
-             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
-             patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
-             patch('importlib.import_module', side_effect=ImportError("Test import error")):
-            
-            mock_discover.return_value = ['broken_plugin']
-            
+        with patch("sys.argv", ["toolkit"]), patch(
+            "sys.stderr", new_callable=StringIO
+        ) as mock_stderr, patch(
+            "asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins"
+        ) as mock_discover, patch(
+            "importlib.import_module", side_effect=ImportError("Test import error")
+        ):
+
+            mock_discover.return_value = ["broken_plugin"]
+
             toolkit.main()
             error_output = mock_stderr.getvalue()
             self.assertIn("Error loading plugin", error_output)
 
-    @patch('sys.argv', ['toolkit', 'EntityReference', '--help'])
+    @patch("sys.argv", ["toolkit", "EntityReference", "--help"])
     def test_plugin_help(self):
         """Test that plugin help works correctly."""
 
@@ -99,6 +104,7 @@ class TestEntityReferencePlugin(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         from asciidoc_dita_toolkit.asciidoc_dita.plugins import EntityReference
+
         self.plugin = EntityReference
 
     def test_replace_entities_supported(self):
@@ -116,9 +122,11 @@ class TestEntityReferencePlugin(unittest.TestCase):
     def test_replace_entities_unknown(self):
         """Test handling of unknown entities."""
         input_line = "Unknown &unknown; entity"
-        with patch('builtins.print') as mock_print:
+        with patch("builtins.print") as mock_print:
             result = self.plugin.replace_entities(input_line)
-            mock_print.assert_called_with("Warning: No AsciiDoc attribute for &unknown;")
+            mock_print.assert_called_with(
+                "Warning: No AsciiDoc attribute for &unknown;"
+            )
             self.assertEqual(result, input_line)
 
 
@@ -128,22 +136,23 @@ class TestContentTypePlugin(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         from asciidoc_dita_toolkit.asciidoc_dita.plugins import ContentType
+
         self.plugin = ContentType
 
     def test_get_content_type_from_filename(self):
         """Test content type detection from filename."""
         test_cases = [
-            ('assembly_test.adoc', 'ASSEMBLY'),
-            ('assembly-test.adoc', 'ASSEMBLY'),
-            ('con_test.adoc', 'CONCEPT'),
-            ('con-test.adoc', 'CONCEPT'),
-            ('proc_test.adoc', 'PROCEDURE'),
-            ('proc-test.adoc', 'PROCEDURE'),
-            ('ref_test.adoc', 'REFERENCE'),
-            ('ref-test.adoc', 'REFERENCE'),
-            ('snip_test.adoc', 'SNIPPET'),
-            ('snip-test.adoc', 'SNIPPET'),
-            ('other_test.adoc', None),
+            ("assembly_test.adoc", "ASSEMBLY"),
+            ("assembly-test.adoc", "ASSEMBLY"),
+            ("con_test.adoc", "CONCEPT"),
+            ("con-test.adoc", "CONCEPT"),
+            ("proc_test.adoc", "PROCEDURE"),
+            ("proc-test.adoc", "PROCEDURE"),
+            ("ref_test.adoc", "REFERENCE"),
+            ("ref-test.adoc", "REFERENCE"),
+            ("snip_test.adoc", "SNIPPET"),
+            ("snip-test.adoc", "SNIPPET"),
+            ("other_test.adoc", None),
         ]
 
         for filename, expected in test_cases:
@@ -153,43 +162,51 @@ class TestContentTypePlugin(unittest.TestCase):
 
     def test_add_content_type_label_new_file(self):
         """Test adding content type label to a file without one."""
-        with tempfile.NamedTemporaryFile(mode='w+', suffix='.adoc', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".adoc", delete=False
+        ) as tmp:
             tmp.write("= Test Document\n\nContent here.\n")
             tmp.flush()
-            
+
             try:
-                with patch('builtins.print') as mock_print:
-                    self.plugin.add_content_type_label(tmp.name, 'CONCEPT')
-                
-                with open(tmp.name, 'r') as f:
+                with patch("builtins.print") as mock_print:
+                    self.plugin.add_content_type_label(tmp.name, "CONCEPT")
+
+                with open(tmp.name, "r") as f:
                     content = f.read()
-                
-                self.assertIn(':_mod-docs-content-type: CONCEPT', content)
+
+                self.assertIn(":_mod-docs-content-type: CONCEPT", content)
                 mock_print.assert_called()
             finally:
                 os.unlink(tmp.name)
 
     def test_add_content_type_label_existing_label(self):
         """Test that existing labels are not overwritten."""
-        with tempfile.NamedTemporaryFile(mode='w+', suffix='.adoc', delete=False) as tmp:
-            tmp.write(":_mod-docs-content-type: PROCEDURE\n= Test Document\n\nContent here.\n")
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".adoc", delete=False
+        ) as tmp:
+            tmp.write(
+                ":_mod-docs-content-type: PROCEDURE\n= Test Document\n\nContent here.\n"
+            )
             tmp.flush()
-            
+
             try:
-                with patch('builtins.print') as mock_print:
-                    self.plugin.add_content_type_label(tmp.name, 'CONCEPT')
-                
-                with open(tmp.name, 'r') as f:
+                with patch("builtins.print") as mock_print:
+                    self.plugin.add_content_type_label(tmp.name, "CONCEPT")
+
+                with open(tmp.name, "r") as f:
                     content = f.read()
-                
+
                 # Should still have the original label
-                self.assertIn(':_mod-docs-content-type: PROCEDURE', content)
+                self.assertIn(":_mod-docs-content-type: PROCEDURE", content)
                 # Should not have the new label
-                self.assertNotIn(':_mod-docs-content-type: CONCEPT', content)
-                mock_print.assert_called_with(f"Skipping {tmp.name}, label already present")
+                self.assertNotIn(":_mod-docs-content-type: CONCEPT", content)
+                mock_print.assert_called_with(
+                    f"Skipping {tmp.name}, label already present"
+                )
             finally:
                 os.unlink(tmp.name)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,15 @@
 """
 Test suite for the CLI interface of the AsciiDoc DITA toolkit.
 """
-
+import unittest
+import tempfile
 import os
 import sys
-import tempfile
-import unittest
+from unittest.mock import patch, MagicMock
 from io import StringIO
-from unittest.mock import MagicMock, patch
 
 # Add the project root to the path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from asciidoc_dita_toolkit.asciidoc_dita import toolkit
 
@@ -22,72 +21,68 @@ class TestCLI(unittest.TestCase):
         """Test that plugin discovery works correctly."""
         plugins = toolkit.discover_plugins()
         self.assertIsInstance(plugins, list)
-        self.assertIn("EntityReference", plugins)
-        self.assertIn("ContentType", plugins)
+        self.assertIn('EntityReference', plugins)
+        self.assertIn('ContentType', plugins)
 
-    @patch("sys.stdout", new_callable=StringIO)
+    @patch('sys.stdout', new_callable=StringIO)
     def test_list_plugins(self, mock_stdout):
         """Test the --list-plugins functionality."""
         toolkit.print_plugin_list()
         output = mock_stdout.getvalue()
-        self.assertIn("Available plugins:", output)
-        self.assertIn("EntityReference", output)
-        self.assertIn("ContentType", output)
+        self.assertIn('Available plugins:', output)
+        self.assertIn('EntityReference', output)
+        self.assertIn('ContentType', output)
 
-    @patch("sys.argv", ["toolkit", "--list-plugins"])
-    @patch("sys.exit")
-    @patch("sys.stdout", new_callable=StringIO)
+    @patch('sys.argv', ['toolkit', '--list-plugins'])
+    @patch('sys.exit')
+    @patch('sys.stdout', new_callable=StringIO)
     def test_main_list_plugins(self, mock_stdout, mock_exit):
         """Test main function with --list-plugins argument."""
         toolkit.main()
         mock_exit.assert_called_once_with(0)
         output = mock_stdout.getvalue()
-        self.assertIn("Available plugins:", output)
+        self.assertIn('Available plugins:', output)
 
-    @patch("sys.argv", ["toolkit"])
-    @patch("sys.stdout", new_callable=StringIO)
+    @patch('sys.argv', ['toolkit'])
+    @patch('sys.stdout', new_callable=StringIO)
     def test_main_no_args(self, mock_stdout):
         """Test main function with no arguments shows help."""
         toolkit.main()
         output = mock_stdout.getvalue()
-        self.assertIn("usage:", output)
+        self.assertIn('usage:', output)
 
     def test_plugin_loading_with_missing_function(self):
         """Test handling of plugins missing register_subcommand function."""
-        with patch("sys.argv", ["toolkit"]), patch(
-            "sys.stderr", new_callable=StringIO
-        ) as mock_stderr, patch(
-            "asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins"
-        ) as mock_discover, patch(
-            "importlib.import_module"
-        ) as mock_import:
-
-            mock_discover.return_value = ["test_plugin"]
+        with patch('sys.argv', ['toolkit']), \
+             patch('sys.stderr', new_callable=StringIO) as mock_stderr, \
+             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
+             patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
+             patch('importlib.import_module') as mock_import:
+            
+            mock_discover.return_value = ['test_plugin']
             mock_module = MagicMock()
             del mock_module.register_subcommand  # Remove the function
             mock_import.return_value = mock_module
-
+            
             toolkit.main()
             error_output = mock_stderr.getvalue()
             self.assertIn("missing register_subcommand function", error_output)
 
     def test_plugin_loading_with_import_error(self):
         """Test handling of plugin import errors."""
-        with patch("sys.argv", ["toolkit"]), patch(
-            "sys.stderr", new_callable=StringIO
-        ) as mock_stderr, patch(
-            "asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins"
-        ) as mock_discover, patch(
-            "importlib.import_module", side_effect=ImportError("Test import error")
-        ):
-
-            mock_discover.return_value = ["broken_plugin"]
-
+        with patch('sys.argv', ['toolkit']), \
+             patch('sys.stderr', new_callable=StringIO) as mock_stderr, \
+             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
+             patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
+             patch('importlib.import_module', side_effect=ImportError("Test import error")):
+            
+            mock_discover.return_value = ['broken_plugin']
+            
             toolkit.main()
             error_output = mock_stderr.getvalue()
             self.assertIn("Error loading plugin", error_output)
 
-    @patch("sys.argv", ["toolkit", "EntityReference", "--help"])
+    @patch('sys.argv', ['toolkit', 'EntityReference', '--help'])
     def test_plugin_help(self):
         """Test that plugin help works correctly."""
 
@@ -104,7 +99,6 @@ class TestEntityReferencePlugin(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         from asciidoc_dita_toolkit.asciidoc_dita.plugins import EntityReference
-
         self.plugin = EntityReference
 
     def test_replace_entities_supported(self):
@@ -122,11 +116,9 @@ class TestEntityReferencePlugin(unittest.TestCase):
     def test_replace_entities_unknown(self):
         """Test handling of unknown entities."""
         input_line = "Unknown &unknown; entity"
-        with patch("builtins.print") as mock_print:
+        with patch('builtins.print') as mock_print:
             result = self.plugin.replace_entities(input_line)
-            mock_print.assert_called_with(
-                "Warning: No AsciiDoc attribute for &unknown;"
-            )
+            mock_print.assert_called_with("Warning: No AsciiDoc attribute for &unknown;")
             self.assertEqual(result, input_line)
 
 
@@ -136,23 +128,22 @@ class TestContentTypePlugin(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         from asciidoc_dita_toolkit.asciidoc_dita.plugins import ContentType
-
         self.plugin = ContentType
 
     def test_get_content_type_from_filename(self):
         """Test content type detection from filename."""
         test_cases = [
-            ("assembly_test.adoc", "ASSEMBLY"),
-            ("assembly-test.adoc", "ASSEMBLY"),
-            ("con_test.adoc", "CONCEPT"),
-            ("con-test.adoc", "CONCEPT"),
-            ("proc_test.adoc", "PROCEDURE"),
-            ("proc-test.adoc", "PROCEDURE"),
-            ("ref_test.adoc", "REFERENCE"),
-            ("ref-test.adoc", "REFERENCE"),
-            ("snip_test.adoc", "SNIPPET"),
-            ("snip-test.adoc", "SNIPPET"),
-            ("other_test.adoc", None),
+            ('assembly_test.adoc', 'ASSEMBLY'),
+            ('assembly-test.adoc', 'ASSEMBLY'),
+            ('con_test.adoc', 'CONCEPT'),
+            ('con-test.adoc', 'CONCEPT'),
+            ('proc_test.adoc', 'PROCEDURE'),
+            ('proc-test.adoc', 'PROCEDURE'),
+            ('ref_test.adoc', 'REFERENCE'),
+            ('ref-test.adoc', 'REFERENCE'),
+            ('snip_test.adoc', 'SNIPPET'),
+            ('snip-test.adoc', 'SNIPPET'),
+            ('other_test.adoc', None),
         ]
 
         for filename, expected in test_cases:
@@ -162,51 +153,43 @@ class TestContentTypePlugin(unittest.TestCase):
 
     def test_add_content_type_label_new_file(self):
         """Test adding content type label to a file without one."""
-        with tempfile.NamedTemporaryFile(
-            mode="w+", suffix=".adoc", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode='w+', suffix='.adoc', delete=False) as tmp:
             tmp.write("= Test Document\n\nContent here.\n")
             tmp.flush()
-
+            
             try:
-                with patch("builtins.print") as mock_print:
-                    self.plugin.add_content_type_label(tmp.name, "CONCEPT")
-
-                with open(tmp.name, "r") as f:
+                with patch('builtins.print') as mock_print:
+                    self.plugin.add_content_type_label(tmp.name, 'CONCEPT')
+                
+                with open(tmp.name, 'r') as f:
                     content = f.read()
-
-                self.assertIn(":_mod-docs-content-type: CONCEPT", content)
+                
+                self.assertIn(':_mod-docs-content-type: CONCEPT', content)
                 mock_print.assert_called()
             finally:
                 os.unlink(tmp.name)
 
     def test_add_content_type_label_existing_label(self):
         """Test that existing labels are not overwritten."""
-        with tempfile.NamedTemporaryFile(
-            mode="w+", suffix=".adoc", delete=False
-        ) as tmp:
-            tmp.write(
-                ":_mod-docs-content-type: PROCEDURE\n= Test Document\n\nContent here.\n"
-            )
+        with tempfile.NamedTemporaryFile(mode='w+', suffix='.adoc', delete=False) as tmp:
+            tmp.write(":_mod-docs-content-type: PROCEDURE\n= Test Document\n\nContent here.\n")
             tmp.flush()
-
+            
             try:
-                with patch("builtins.print") as mock_print:
-                    self.plugin.add_content_type_label(tmp.name, "CONCEPT")
-
-                with open(tmp.name, "r") as f:
+                with patch('builtins.print') as mock_print:
+                    self.plugin.add_content_type_label(tmp.name, 'CONCEPT')
+                
+                with open(tmp.name, 'r') as f:
                     content = f.read()
-
+                
                 # Should still have the original label
-                self.assertIn(":_mod-docs-content-type: PROCEDURE", content)
+                self.assertIn(':_mod-docs-content-type: PROCEDURE', content)
                 # Should not have the new label
-                self.assertNotIn(":_mod-docs-content-type: CONCEPT", content)
-                mock_print.assert_called_with(
-                    f"Skipping {tmp.name}, label already present"
-                )
+                self.assertNotIn(':_mod-docs-content-type: CONCEPT', content)
+                mock_print.assert_called_with(f"Skipping {tmp.name}, label already present")
             finally:
                 os.unlink(tmp.name)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,16 @@
 """
 Test suite for the CLI interface of the AsciiDoc DITA toolkit.
 """
-import unittest
-import tempfile
+
 import os
 import sys
-from unittest.mock import patch, MagicMock
+import tempfile
+import unittest
 from io import StringIO
+from unittest.mock import MagicMock, patch
 
 # Add the project root to the path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from asciidoc_dita_toolkit.asciidoc_dita import toolkit
 
@@ -21,35 +22,35 @@ class TestCLI(unittest.TestCase):
         """Test that plugin discovery works correctly."""
         plugins = toolkit.discover_plugins()
         self.assertIsInstance(plugins, list)
-        self.assertIn('EntityReference', plugins)
-        self.assertIn('ContentType', plugins)
+        self.assertIn("EntityReference", plugins)
+        self.assertIn("ContentType", plugins)
 
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.stdout", new_callable=StringIO)
     def test_list_plugins(self, mock_stdout):
         """Test the --list-plugins functionality."""
         toolkit.print_plugin_list()
         output = mock_stdout.getvalue()
-        self.assertIn('Available plugins:', output)
-        self.assertIn('EntityReference', output)
-        self.assertIn('ContentType', output)
+        self.assertIn("Available plugins:", output)
+        self.assertIn("EntityReference", output)
+        self.assertIn("ContentType", output)
 
-    @patch('sys.argv', ['toolkit', '--list-plugins'])
-    @patch('sys.exit')
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.argv", ["toolkit", "--list-plugins"])
+    @patch("sys.exit")
+    @patch("sys.stdout", new_callable=StringIO)
     def test_main_list_plugins(self, mock_stdout, mock_exit):
         """Test main function with --list-plugins argument."""
         toolkit.main()
         mock_exit.assert_called_once_with(0)
         output = mock_stdout.getvalue()
-        self.assertIn('Available plugins:', output)
+        self.assertIn("Available plugins:", output)
 
-    @patch('sys.argv', ['toolkit'])
-    @patch('sys.stdout', new_callable=StringIO)
+    @patch("sys.argv", ["toolkit"])
+    @patch("sys.stdout", new_callable=StringIO)
     def test_main_no_args(self, mock_stdout):
         """Test main function with no arguments shows help."""
         toolkit.main()
         output = mock_stdout.getvalue()
-        self.assertIn('usage:', output)
+        self.assertIn("usage:", output)
 
     def test_plugin_loading_with_missing_function(self):
         """Test handling of plugins missing register_subcommand function."""
@@ -58,12 +59,12 @@ class TestCLI(unittest.TestCase):
              patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
              patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
              patch('importlib.import_module') as mock_import:
-            
+
             mock_discover.return_value = ['test_plugin']
             mock_module = MagicMock()
             del mock_module.register_subcommand  # Remove the function
             mock_import.return_value = mock_module
-            
+
             toolkit.main()
             error_output = mock_stderr.getvalue()
             self.assertIn("missing register_subcommand function", error_output)
@@ -75,14 +76,14 @@ class TestCLI(unittest.TestCase):
              patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
              patch('asciidoc_dita_toolkit.asciidoc_dita.toolkit.discover_plugins') as mock_discover, \
              patch('importlib.import_module', side_effect=ImportError("Test import error")):
-            
+
             mock_discover.return_value = ['broken_plugin']
-            
+
             toolkit.main()
             error_output = mock_stderr.getvalue()
             self.assertIn("Error loading plugin", error_output)
 
-    @patch('sys.argv', ['toolkit', 'EntityReference', '--help'])
+    @patch("sys.argv", ["toolkit", "EntityReference", "--help"])
     def test_plugin_help(self):
         """Test that plugin help works correctly."""
 
@@ -99,6 +100,7 @@ class TestEntityReferencePlugin(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         from asciidoc_dita_toolkit.asciidoc_dita.plugins import EntityReference
+
         self.plugin = EntityReference
 
     def test_replace_entities_supported(self):
@@ -116,9 +118,11 @@ class TestEntityReferencePlugin(unittest.TestCase):
     def test_replace_entities_unknown(self):
         """Test handling of unknown entities."""
         input_line = "Unknown &unknown; entity"
-        with patch('builtins.print') as mock_print:
+        with patch("builtins.print") as mock_print:
             result = self.plugin.replace_entities(input_line)
-            mock_print.assert_called_with("Warning: No AsciiDoc attribute for &unknown;")
+            mock_print.assert_called_with(
+                "Warning: No AsciiDoc attribute for &unknown;"
+            )
             self.assertEqual(result, input_line)
 
 
@@ -128,22 +132,23 @@ class TestContentTypePlugin(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         from asciidoc_dita_toolkit.asciidoc_dita.plugins import ContentType
+
         self.plugin = ContentType
 
     def test_get_content_type_from_filename(self):
         """Test content type detection from filename."""
         test_cases = [
-            ('assembly_test.adoc', 'ASSEMBLY'),
-            ('assembly-test.adoc', 'ASSEMBLY'),
-            ('con_test.adoc', 'CONCEPT'),
-            ('con-test.adoc', 'CONCEPT'),
-            ('proc_test.adoc', 'PROCEDURE'),
-            ('proc-test.adoc', 'PROCEDURE'),
-            ('ref_test.adoc', 'REFERENCE'),
-            ('ref-test.adoc', 'REFERENCE'),
-            ('snip_test.adoc', 'SNIPPET'),
-            ('snip-test.adoc', 'SNIPPET'),
-            ('other_test.adoc', None),
+            ("assembly_test.adoc", "ASSEMBLY"),
+            ("assembly-test.adoc", "ASSEMBLY"),
+            ("con_test.adoc", "CONCEPT"),
+            ("con-test.adoc", "CONCEPT"),
+            ("proc_test.adoc", "PROCEDURE"),
+            ("proc-test.adoc", "PROCEDURE"),
+            ("ref_test.adoc", "REFERENCE"),
+            ("ref-test.adoc", "REFERENCE"),
+            ("snip_test.adoc", "SNIPPET"),
+            ("snip-test.adoc", "SNIPPET"),
+            ("other_test.adoc", None),
         ]
 
         for filename, expected in test_cases:
@@ -153,43 +158,51 @@ class TestContentTypePlugin(unittest.TestCase):
 
     def test_add_content_type_label_new_file(self):
         """Test adding content type label to a file without one."""
-        with tempfile.NamedTemporaryFile(mode='w+', suffix='.adoc', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".adoc", delete=False
+        ) as tmp:
             tmp.write("= Test Document\n\nContent here.\n")
             tmp.flush()
-            
+
             try:
-                with patch('builtins.print') as mock_print:
-                    self.plugin.add_content_type_label(tmp.name, 'CONCEPT')
-                
-                with open(tmp.name, 'r') as f:
+                with patch("builtins.print") as mock_print:
+                    self.plugin.add_content_type_label(tmp.name, "CONCEPT")
+
+                with open(tmp.name, "r") as f:
                     content = f.read()
-                
-                self.assertIn(':_mod-docs-content-type: CONCEPT', content)
+
+                self.assertIn(":_mod-docs-content-type: CONCEPT", content)
                 mock_print.assert_called()
             finally:
                 os.unlink(tmp.name)
 
     def test_add_content_type_label_existing_label(self):
         """Test that existing labels are not overwritten."""
-        with tempfile.NamedTemporaryFile(mode='w+', suffix='.adoc', delete=False) as tmp:
-            tmp.write(":_mod-docs-content-type: PROCEDURE\n= Test Document\n\nContent here.\n")
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".adoc", delete=False
+        ) as tmp:
+            tmp.write(
+                ":_mod-docs-content-type: PROCEDURE\n= Test Document\n\nContent here.\n"
+            )
             tmp.flush()
-            
+
             try:
-                with patch('builtins.print') as mock_print:
-                    self.plugin.add_content_type_label(tmp.name, 'CONCEPT')
-                
-                with open(tmp.name, 'r') as f:
+                with patch("builtins.print") as mock_print:
+                    self.plugin.add_content_type_label(tmp.name, "CONCEPT")
+
+                with open(tmp.name, "r") as f:
                     content = f.read()
-                
+
                 # Should still have the original label
-                self.assertIn(':_mod-docs-content-type: PROCEDURE', content)
+                self.assertIn(":_mod-docs-content-type: PROCEDURE", content)
                 # Should not have the new label
-                self.assertNotIn(':_mod-docs-content-type: CONCEPT', content)
-                mock_print.assert_called_with(f"Skipping {tmp.name}, label already present")
+                self.assertNotIn(":_mod-docs-content-type: CONCEPT", content)
+                mock_print.assert_called_with(
+                    f"Skipping {tmp.name}, label already present"
+                )
             finally:
                 os.unlink(tmp.name)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Remove overly restrictive upper bounds in requirements-dev.txt
- Use minimum version constraints only (e.g., black>=22.1.0)
- Add code quality checks to CI pipeline (linting, formatting, import sorting)
- Format all Python code with Black and isort for consistency
- Address @jhradilek's feedback about dependency flexibility
- CI now runs linting checks to catch code quality issues in PRs **but allows them to pass.**

Fixes #57 dependency installation issues caused by overly specific version pinning