### PR TITLE
ci: disable container builds on pull requests

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -6,8 +6,6 @@ on:
     branches: ['main']
   release:
     types: [published]
-  pull_request:
-    branches: ['main']
 
 env:
   REGISTRY_GHCR: ghcr.io


### PR DESCRIPTION
- Remove pull_request trigger from container-build workflow
- Container builds now only run on main branch pushes and releases
- Reduces CI time and GitHub Actions usage for PRs
- Container builds still happen when actually needed