### PR TITLE
Evaluate and fix GitHub issue 97

### DIFF
--- a/asciidoc_dita_toolkit/asciidoc_dita/toolkit.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/toolkit.py
@@ -35,10 +35,16 @@ def discover_plugins():
 
 def print_plugin_list():
     """Print a list of all available plugins with their descriptions."""
+    from .plugin_manager import is_plugin_enabled
+    
     print("Available plugins:")
     plugins = discover_plugins()
 
     for modname in plugins:
+        # Only show enabled plugins in the list
+        if not is_plugin_enabled(modname):
+            continue
+            
         try:
             module = importlib.import_module(
                 f".plugins.{modname}", package="asciidoc_dita_toolkit.asciidoc_dita"
@@ -52,6 +58,8 @@ def print_plugin_list():
 
 def main():
     """Main entry point for the AsciiDoc DITA toolkit."""
+    from .plugin_manager import is_plugin_enabled
+    
     parser = argparse.ArgumentParser(
         description="AsciiDoc DITA Toolkit - Process and validate AsciiDoc files for DITA publishing"
     )
@@ -67,11 +75,15 @@ def main():
     )
     subparsers = parser.add_subparsers(dest="command", required=False)
 
-    # Discover and register all plugins
+    # Discover and register only enabled plugins
     plugins = discover_plugins()
     plugin_modules = []
 
     for modname in plugins:
+        # Only register enabled plugins as CLI subcommands
+        if not is_plugin_enabled(modname):
+            continue
+            
         try:
             module = importlib.import_module(
                 f".plugins.{modname}", package="asciidoc_dita_toolkit.asciidoc_dita"

--- a/asciidoc_dita_toolkit/asciidoc_dita/toolkit.py
+++ b/asciidoc_dita_toolkit/asciidoc_dita/toolkit.py
@@ -11,6 +11,8 @@ import importlib.metadata
 import os
 import sys
 
+from .plugin_manager import is_plugin_enabled
+
 PLUGIN_DIR = os.path.join(os.path.dirname(__file__), "plugins")
 
 
@@ -35,8 +37,6 @@ def discover_plugins():
 
 def print_plugin_list():
     """Print a list of all available plugins with their descriptions."""
-    from .plugin_manager import is_plugin_enabled
-    
     print("Available plugins:")
     plugins = discover_plugins()
 
@@ -58,8 +58,6 @@ def print_plugin_list():
 
 def main():
     """Main entry point for the AsciiDoc DITA toolkit."""
-    from .plugin_manager import is_plugin_enabled
-    
     parser = argparse.ArgumentParser(
         description="AsciiDoc DITA Toolkit - Process and validate AsciiDoc files for DITA publishing"
     )


### PR DESCRIPTION
Fix issue #97: CLI plugin discovery respects plugin enablement status.

This PR ensures that the CLI (`toolkit.py`) correctly uses `is_plugin_enabled()` from the plugin manager. Previously, preview plugins would appear in `--help` and `--list-plugins` output even when disabled by environment variables. This change filters plugins based on their enablement status, aligning CLI behavior with the plugin management system and fixing related test failures.