### PR TITLE
Enhancement: Add plugin versions to --version output

### DIFF
--- a/src/adt_core/cli.py
+++ b/src/adt_core/cli.py
@@ -109,6 +109,48 @@ def get_version():
             return "unknown"
 
 
+def print_version_with_plugins():
+    """Print version information including plugin versions."""
+    # Print main tool version
+    version = get_version()
+    print(f"adt {version}")
+    print("AsciiDoc DITA Toolkit - unified package for technical documentation workflows")
+    print("https://github.com/rolfedh/asciidoc-dita-toolkit")
+    print()
+    
+    # Get plugin information
+    legacy_plugins = get_legacy_plugins()
+    new_modules = get_new_modules_for_help()
+    
+    # Combine and sort all plugins with version info
+    all_plugins = []
+    
+    # Add new modules first (they have proper version info)
+    for name, info in new_modules.items():
+        desc = PLUGIN_DESCRIPTIONS.get(name, info['description'])
+        version_str = info['module'].version
+        all_plugins.append((name, version_str, desc))
+    
+    # Add legacy plugins only if they don't exist in new modules
+    for name, info in legacy_plugins.items():
+        if name not in new_modules:
+            desc = PLUGIN_DESCRIPTIONS.get(name, info['description'])
+            # Try to get version from module, fallback to 'legacy'
+            version_str = getattr(info.get('module'), '__version__', 'legacy')
+            all_plugins.append((name, version_str, desc))
+    
+    if all_plugins:
+        print("AVAILABLE PLUGINS:")
+        # Sort by plugin name
+        all_plugins.sort(key=lambda x: x[0])
+        
+        # Print in table format
+        for name, version_str, desc in all_plugins:
+            print(f"  {name:<18} v{version_str:<8} {desc}")
+    else:
+        print("No plugins available")
+
+
 def get_legacy_plugins():
     """Get available legacy plugins from the old system."""
     plugins = {}
@@ -520,12 +562,7 @@ def main(args=None):
 
     # Handle special flags
     if parsed_args.version:
-        version = get_version()
-        print(f"adt {version}")
-        print(
-            "AsciiDoc DITA Toolkit - unified package for technical documentation workflows"
-        )
-        print("https://github.com/rolfedh/asciidoc-dita-toolkit")
+        print_version_with_plugins()
         sys.exit(0)
 
     if parsed_args.list_plugins:


### PR DESCRIPTION
Fixes #135 

- Add print_version_with_plugins() function to display plugin version information
- Enhance --version command to show comprehensive version details
- Display plugin names, versions, and descriptions in table format
- Prioritize new modules with explicit version info over legacy plugins
- Maintain existing functionality while providing richer version information

Example output:
  ContentType        v2.1.0    Add/update content type attributes
  ContextAnalyzer    v1.2.0    Analyze context IDs and cross-references
  CrossReference     v2.0.0    Validate and fix cross-references between files"