### PR TITLE
Fix #132: Create common path calculation utility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Common test utilities and fixtures for the asciidoc-dita-toolkit test suite.
+
+This module provides shared functionality to eliminate code duplication across test files.
+"""
+
+import sys
+from pathlib import Path
+
+
+def get_workspace_root() -> Path:
+    """
+    Get the workspace root directory path.
+    
+    Returns:
+        Path: The workspace root directory (project root)
+    """
+    return Path(__file__).parent.parent
+
+
+def setup_test_paths() -> tuple[Path, Path]:
+    """
+    Set up common test paths and add them to sys.path.
+    
+    This function calculates the workspace root and source paths,
+    then adds them to sys.path for imports.
+    
+    Returns:
+        tuple[Path, Path]: A tuple of (workspace_root, src_path)
+    """
+    workspace_root = get_workspace_root()
+    src_path = workspace_root / "src"
+    
+    # Add paths to sys.path if not already present
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+    if str(workspace_root) not in sys.path:
+        sys.path.insert(0, str(workspace_root))
+    
+    return workspace_root, src_path


### PR DESCRIPTION
- Created tests/conftest.py with shared utility functions:
  * get_workspace_root() - returns workspace root directory
  * setup_test_paths() - sets up common test paths and adds to sys.path
- Updated 4 test files to use shared utility instead of duplicate code:
  * test_documentation_alignment.py
  * test_adt_configuration_validation.py
  * test_migration_phases.py
  * test_performance_baseline.py
- Eliminates code duplication of 'workspace_root = Path(__file__).parent.parent' pattern
- Improves maintainability and ensures consistency across test suite
- All tests pass (except unrelated pytest import issue in #144)

Closes #132