### PR TITLE
Fix GitHub Pages workflow and Jekyll configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build with Jekyll
         run: |
           cd user-guide
-          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}/user-guide"
+          bundle exec jekyll build
         env:
           JEKYLL_ENV: production
           

--- a/user-guide/Gemfile
+++ b/user-guide/Gemfile
@@ -1,13 +1,9 @@
 source 'https://rubygems.org'
 
 gem "jekyll", "~> 4.3.0"
-gem "just-the-docs", "0.8.2"
 
 group :jekyll_plugins do
   gem "jekyll-remote-theme"
-  gem "jekyll-feed"
-  gem "jekyll-sitemap"
-  gem "jekyll-seo-tag"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
- Remove baseurl override in workflow to prevent conflicts with _config.yml
- Simplify Gemfile to only essential Jekyll dependencies
- Let Jekyll use the baseurl from _config.yml consistently