### PR TITLE
Disable Docker workflow automatic triggers due to auth issues

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,11 +1,15 @@
 name: Build and Push Container Images
 
+# DISABLED: Docker Hub authentication issues need to be resolved
+# See GitHub issue for details
 on:
-  push:
-    tags: ['v*']
-    branches: ['main']
-  release:
-    types: [published]
+  # Disabled temporarily due to Docker Hub auth issues
+  # push:
+  #   tags: ['v*']
+  #   branches: ['main']
+  # release:
+  #   types: [published]
+  workflow_dispatch:  # Keep manual trigger available
 
 env:
   REGISTRY_GHCR: ghcr.io


### PR DESCRIPTION
- Comment out push and release triggers
- Keep workflow_dispatch for manual execution
- See GitHub issue for tracking fix
https://github.com/rolfedh/asciidoc-dita-toolkit/issues/158