### PR TITLE
Fix Jekyll theme deployment - remove conflicting github-pages gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'jekyll', '~> 4.3.0'
 gem 'minima', '~> 2.5'
-gem 'github-pages', group: :jekyll_plugins
 
 # Jekyll plugins
 group :jekyll_plugins do

--- a/user-guide/_config.yml
+++ b/user-guide/_config.yml
@@ -1,6 +1,6 @@
 title: AsciiDoc DITA Toolkit
 description: Documentation for technical writers preparing AsciiDoc content for DITA migration
-baseurl: "/asciidoc-dita-toolkit/user-guide"
+baseurl: "/asciidoc-dita-toolkit"
 url: "https://rolfedh.github.io"
 
 # Modern theme - Just the Docs


### PR DESCRIPTION
## Problem
The GitHub Pages deployment was failing because of a conflicting `github-pages` gem in the root Gemfile that requires Ruby 1.9.3, while our modern Jekyll setup uses Ruby 3.1.

## Error in Workflow
```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    github-pages was resolved to 1, which depends on
      Ruby (~> 1.9.3)
    jekyll (~> 4.3.0) was resolved to 4.3.4, which depends on
      Ruby (>= 2.5.0)
```

## Changes
- ✅ Removed `github-pages` gem from root Gemfile (conflicts with modern Jekyll)
- ✅ Fixed baseurl configuration in `user-guide/_config.yml` 
- ✅ Modern Jekyll 4.3 + Just the Docs theme should now deploy properly

## Expected Result
- GitHub Pages workflow should now succeed
- Documentation site should display with proper Just the Docs theme styling
- No more Ruby version conflicts

## Testing
The workflow will run automatically when this PR is merged to main.