### PR TITLE
Add missing Jekyll plugins required by Just the Docs theme

### DIFF
--- a/user-guide/Gemfile
+++ b/user-guide/Gemfile
@@ -4,6 +4,8 @@ gem "jekyll", "~> 4.3.0"
 
 group :jekyll_plugins do
   gem "jekyll-remote-theme"
+  gem "jekyll-seo-tag"
+  gem "jekyll-include-cache"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
## Problem
The Jekyll build was failing because the Just the Docs theme requires additional plugins that were missing from the Gemfile:
- `jekyll-seo-tag` 
- `jekyll-include-cache`

## Error in Workflow
```
Dependency Error: Yikes! It looks like you don't have jekyll-seo-tag or one of its dependencies installed.
```

## Changes
- ✅ Added `jekyll-seo-tag` (required by Just the Docs theme)
- ✅ Added `jekyll-include-cache` (required by Just the Docs theme) 
- ✅ These are the exact dependencies specified in the theme's gemspec

## Expected Result
- Jekyll build should succeed
- Just the Docs theme should load properly with all styling and functionality
- Documentation site should finally display with the modern, professional appearance

## Testing
This will be tested automatically when the PR is merged and triggers the Pages workflow.