### PR TITLE
Update README: Clarify Python Prerequisites and Container Option, Add adt-docker Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A command-line toolkit for technical writers to review and fix AsciiDoc content 
 The AsciiDoc DITA Toolkit helps you:
 
 - **Find and fix** common issues in `.adoc` files before publishing
-- **Apply automated checks** and transformations using a plugin system  
+- **Apply automated checks** and transformations using a plugin system
 - **Ensure consistency** across large documentation projects
 - **Integrate** with your existing documentation workflow
 
@@ -22,17 +22,7 @@ The AsciiDoc DITA Toolkit helps you:
 
 ## � Quick Start
 
-### Option 1: Container (Recommended)
-
-```sh
-# Run on current directory
-docker run --rm -v $(pwd):/workspace ghcr.io/rolfedh/asciidoc-dita-toolkit-prod:latest --help
-
-# List available plugins
-docker run --rm -v $(pwd):/workspace ghcr.io/rolfedh/asciidoc-dita-toolkit-prod:latest --list-plugins
-```
-
-### Option 2: Python Package
+### Option 1: Python Package (Recommended)
 
 ```sh
 # Install
@@ -43,13 +33,23 @@ adt --help
 adt --list-plugins
 ```
 
+### Option 2: Container
+
+```sh
+# Run on current directory
+docker run --rm -v $(pwd):/workspace ghcr.io/rolfedh/asciidoc-dita-toolkit-prod:latest --help
+
+# List available plugins
+docker run --rm -v $(pwd):/workspace ghcr.io/rolfedh/asciidoc-dita-toolkit-prod:latest --list-plugins
+```
+
 ## � Basic Usage
 
 ```sh
 # Fix HTML entity references
 adt EntityReference -r
 
-# Add content type labels  
+# Add content type labels
 adt ContentType -r
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# AsciiDoc DITA Tool**👉 Complete documentation and tutorials:** https://rolfedh.github.io/asciidoc-dita-toolkit/
+# AsciiDoc DITA Tool
 
+**👉 Complete documentation and tutorials:** https://rolfedh.github.io/asciidoc-dita-toolkit/
 ## 📋 Prerequisites
 
 ### Option 1: Python Package

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
-# AsciiDoc DITA Toolkit
+# AsciiDoc DITA Tool**👉 Complete documentation and tutorials:** https://rolfedh.github.io/asciidoc-dita-toolkit/
+
+## 📋 Prerequisites
+
+### Option 1: Python Package
+- **Python 3.8+** - Required for the package installation (we recommend upgrading to Python 3.8+)
+- **pip** - Python package manager
+- *Note: If you're using Python 3.7, please use the container option below*
+
+### Option 2: Container
+- **Docker** or **Podman** - Container runtime
+- **curl** - For downloading the wrapper script
+- *Recommended for users on Python 3.7 or those who prefer containerized tools*
+
+## 🚀 Quick Start
 
 [![PyPI version](https://img.shields.io/pypi/v/asciidoc-dita-toolkit.svg)](https://pypi.org/project/asciidoc-dita-toolkit/)
 [![Container](https://img.shields.io/badge/container-ghcr.io-blue?logo=docker)](https://github.com/rolfedh/asciidoc-dita-toolkit/pkgs/container/asciidoc-dita-toolkit-prod)
-[![Python 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A command-line toolkit for technical writers to review and fix AsciiDoc content for DITA-based publishing workflows.
@@ -36,11 +50,12 @@ adt --list-plugins
 ### Option 2: Container
 
 ```sh
-# Run on current directory
-docker run --rm -v $(pwd):/workspace ghcr.io/rolfedh/asciidoc-dita-toolkit-prod:latest --help
+# One-time setup: Download and install adt wrapper
+curl -sSL https://raw.githubusercontent.com/rolfedh/asciidoc-dita-toolkit/main/scripts/adt-docker -o /usr/local/bin/adt && chmod +x /usr/local/bin/adt
 
-# List available plugins
-docker run --rm -v $(pwd):/workspace ghcr.io/rolfedh/asciidoc-dita-toolkit-prod:latest --list-plugins
+# Use
+adt --help
+adt --list-plugins
 ```
 
 ## � Basic Usage

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The AsciiDoc DITA Toolkit helps you:
 
 **👉 Complete documentation and tutorials:** https://rolfedh.github.io/asciidoc-dita-toolkit/
 
-## � Quick Start
+## 🚀 Quick Start
 
 ### Option 1: Python Package (Recommended)
 

--- a/scripts/adt-docker
+++ b/scripts/adt-docker
@@ -1,0 +1,17 @@
+#!/bin/bash
+# AsciiDoc DITA Toolkit - Docker wrapper script
+# This script allows you to use 'adt' commands with the Docker container
+
+set -e
+
+# Container image
+IMAGE="ghcr.io/rolfedh/asciidoc-dita-toolkit-prod:latest"
+
+# Check if Docker is available
+if ! command -v docker &> /dev/null; then
+    echo "Error: Docker is not installed or not in PATH" >&2
+    exit 1
+fi
+
+# Run the container with current directory mounted
+exec docker run --rm -v "$(pwd):/workspace" "$IMAGE" "$@"


### PR DESCRIPTION
Clearly state the Python 3.8+ requirement for package installation and recommend upgrading.
Add guidance for users on Python 3.7, recommending the container option as an alternative.
Improve the Prerequisites section for both package and container usage.
Document the new adt-docker wrapper script, which allows users to run adt commands via Docker with a single setup step.
Provide a one-liner installation command for the wrapper script, making container usage as simple as the Python package.
Ensure users know how to proceed regardless of their Python version or environment.
This improves onboarding for technical writers, makes installation options more accessible, and streamlines container usage with the new wrapper script.