### PR TITLE
Bump ver 2.1.3

### DIFF
--- a/asciidoc_dita_toolkit/adt_core/__init__.py
+++ b/asciidoc_dita_toolkit/adt_core/__init__.py
@@ -17,7 +17,7 @@ from .exceptions import (
     VersionConflictError,
 )
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 
 __all__ = [
     "ModuleSequencer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asciidoc-dita-toolkit"
-version = "2.1.2"
+version = "2.1.3"
 description = "AsciiDoc DITA Toolkit - unified package for technical documentation workflows"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
I need to examine the current Makefile to understand the `make publish` target and then modify it to create a working branch before committing changes. Let me first check the current implementation: Let me continue reading to find the `publish` target: Now I can see the current `publish` target. I need to modify it to create a working branch before committing the changes (around line 321-330). The key changes needed are:

1. Create a new branch before committing
2. Commit the changes to that branch instead of main
3. Push the branch 
4. The tag creation should still work from the branch

Let me update the publish target: 
```


Made changes.


```
Perfect! Now let me also update the help text to reflect this change: 
```


Made changes.


```
Now let me test that the Makefile syntax is correct by running a simple test: Perfect! The Makefile syntax is correct. Let me also verify the key parts of the publish target to make sure the logic flow is right: Excellent! The changes have been successfully implemented. Let me summarize what has been updated:

## ✅ **`make publish` Updated Successfully**

### **Key Changes Made:**

1. **New Step 9: Create Working Branch**
   - Creates a timestamped branch: `release/v{version}-{timestamp}`
   - Example: `release/v1.2.3-20250724-143022`
   - Switches to this branch before making any commits

2. **Updated Step 10: Commit to Branch**
   - Version changes are now committed to the working branch
   - Not committed directly to main branch
   - Clear messaging shows which branch changes are on

3. **Updated Step 11: Push Branch and Tag**
   - Pushes both the working branch and the tag
   - Tag creation triggers GitHub Actions for PyPI publishing
   - Branch contains the version bump commits

4. **Added Warning Messages**
   - Clear notice that changes are on a branch, not main
   - Suggests creating PR if changes need to be merged to main

5. **Updated Help Text**
   - Help text now mentions "create working branch" in the process

### **Benefits:**

- ✅ **Main branch stays clean** - no version bump commits on main
- ✅ **Release process still works** - tags trigger GitHub Actions
- ✅ **Traceable changes** - version bumps are on named release branches  
- ✅ **Optional integration** - you can choose whether to merge branch to main via PR
- ✅ **Timestamped branches** - unique branch names prevent conflicts

### **Workflow Now:**

1. `make publish` creates `release/v1.2.3-20250724-143022` branch
2. Version files updated and committed to that branch
3. Tag `v1.2.3` created and pushed (triggers GitHub Actions)
4. Branch pushed to origin  
5. You can optionally create PR to merge the branch to main later

The release process will work exactly the same way for PyPI publishing and GitHub releases, but the version bump commits won't clutter your main branch!